### PR TITLE
Implement static class for converting JSON to and from an instance of `HostInfo` (previously `Host`)

### DIFF
--- a/benchmarks/EvaluatorBenchmarks.cs
+++ b/benchmarks/EvaluatorBenchmarks.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Jobs;
 
 using OceanApocalypseStudios.RSML.Benchmarks.Dataset;
 using OceanApocalypseStudios.RSML.Evaluation;
+using OceanApocalypseStudios.RSML.Host;
 
 
 namespace OceanApocalypseStudios.RSML.Benchmarks
@@ -111,7 +112,7 @@ namespace OceanApocalypseStudios.RSML.Benchmarks
 
 		}
 
-		private readonly Host ubuntu = new("ubuntu", null, null);
+		private readonly HostInfo ubuntu = new("ubuntu", null, null);
 
 		private Evaluator complexEvaluator1 = null!;
 

--- a/src/RSML.CLI/GlobalSuppressions.cs
+++ b/src/RSML.CLI/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "<Pending>", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CLI.Helpers.HostOutput.FromJson(System.String)~OceanApocalypseStudios.RSML.Host")]
+[assembly: SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "<Pending>", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CLI.Helpers.HostOutput.FromJson(System.String)~OceanApocalypseStudios.RSML.HostInfo")]

--- a/src/RSML.CLI/Helpers/HostOutput.cs
+++ b/src/RSML.CLI/Helpers/HostOutput.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
-using System.Text.Json;
+
+using OceanApocalypseStudios.RSML.Host;
 
 using Spectre.Console;
 
@@ -11,80 +12,59 @@ namespace OceanApocalypseStudios.RSML.CLI.Helpers
 	internal static class HostOutput
 	{
 
-		public static string AsDotnet(Host host) =>
-			host.IsLinux
-				? $"new Host(\"{host.SystemName}\", \"{host.ProcessorArchitecture}\", {host.SystemVersion})"
-				: $"new Host(\"{host.DistroName}\", \"{host.DistroFamily}\", \"{host.ProcessorArchitecture}\", {host.SystemVersion})";
+		public static string AsDotnet(HostInfo hostInfo) =>
+			hostInfo.IsLinux
+				? $"new HostInfo(\"{hostInfo.SystemName}\", \"{hostInfo.ProcessorArchitecture}\", {hostInfo.SystemVersion})"
+				: $"new HostInfo(\"{hostInfo.DistroName}\", \"{hostInfo.DistroFamily}\", \"{hostInfo.ProcessorArchitecture}\", {hostInfo.SystemVersion})";
 
-		public static string AsJson(Host host)
+		public static string AsJson(HostInfo hostInfo) => HostInfoConverter.ToJson(hostInfo);
+
+		public static string AsPlainText(HostInfo hostInfo)
 		{
 
-			string systemVersion = host.StringifiedSystemVersion ?? "null";
-
-			return $$"""
-					 {
-					 	"system": {
-					 		"name": {{Quote(host.SystemName ?? "null")}},
-					 		"version" : {{systemVersion}}
-					 	},
-					 	"linuxDistro": {
-					 		"name": {{Quote(host.DistroName ?? "null")}},
-					 		"family": {{Quote(host.DistroFamily ?? "null")}}
-					 	},
-					 	"processor": {
-					 		"architecture": {{Quote(host.ProcessorArchitecture ?? "null")}}
-					 	}
-					 }
-					 """;
-
-		}
-
-		public static string AsPlainText(Host host)
-		{
-
-			string systemVersion = host.SystemName?.Equals("windows", StringComparison.OrdinalIgnoreCase) ?? false
-									   ? host.SystemVersion switch
+			string systemVersion = hostInfo.SystemName?.Equals("windows", StringComparison.OrdinalIgnoreCase) ?? false
+									   ? hostInfo.SystemVersion switch
 									   {
 
 										   6                  => "Vista",
-										   7 or 8 or 10 or 11 => host.StringifiedSystemVersion!,
+										   7 or 8 or 10 or 11 => hostInfo.StringifiedSystemVersion!,
 										   9                  => "8.1",
 										   _                  => "Unknown"
 
 									   }
-									   : host.StringifiedSystemVersion ?? "Unknown";
+									   : hostInfo.StringifiedSystemVersion ?? "Unknown";
 
-			if (host.SystemVersion == -1)
+			if (hostInfo.SystemVersion == -1)
 				systemVersion = "Unknown";
 
 			return new StringBuilder()
-				   .AppendLine($"System Name: {(host.SystemName ?? "Unknown").Capitalize()}")
+				   .AppendLine($"System Name: {(hostInfo.SystemName ?? "Unknown").Capitalize()}")
 				   .AppendLine($"System Version: {systemVersion}")
 				   .AppendLine()
-				   .AppendLine($"Distro Name: {(host.DistroName ?? "Unknown").Capitalize()}")
-				   .AppendLine($"Distro Family: {(host.DistroFamily ?? "Unknown").Capitalize()}")
+				   .AppendLine($"Distro Name: {(hostInfo.DistroName ?? "Unknown").Capitalize()}")
+				   .AppendLine($"Distro Family: {(hostInfo.DistroFamily ?? "Unknown").Capitalize()}")
 				   .AppendLine()
-				   .AppendLine($"Processor Architecture: {host.ProcessorArchitecture ?? "Unknown"}")
+				   .AppendLine($"Processor Architecture: {hostInfo.ProcessorArchitecture ?? "Unknown"}")
 				   .ToString();
 
 		}
 
-		public static void AsPrettyText(Host host)
+		public static void AsPrettyText(HostInfo hostInfo)
 		{
 
-			string systemVersion = host.SystemName?.Equals("windows", StringComparison.OrdinalIgnoreCase) ?? false
-									   ? host.SystemVersion switch
+			string systemVersion = hostInfo.SystemName?.Equals("windows", StringComparison.OrdinalIgnoreCase) ?? false
+									   ? hostInfo.SystemVersion switch
 									   {
 
 										   6                  => "Vista",
-										   7 or 8 or 10 or 11 => host.StringifiedSystemVersion!,
+										   7 or 8 or 10 or 11 => hostInfo.StringifiedSystemVersion!,
 										   9                  => "8.1",
 										   _                  => "Unknown"
 
 									   }
-									   : host.StringifiedSystemVersion ?? "Unknown";
+									   : hostInfo.StringifiedSystemVersion ?? "Unknown";
 
-			if (host.SystemVersion == -1)
+			if (hostInfo.SystemVersion == -1)
 				systemVersion = "Unknown";
 
 			AnsiConsole.Write(
@@ -95,7 +75,7 @@ namespace OceanApocalypseStudios.RSML.CLI.Helpers
 								new Panel(
 									new Rows(
 										new Markup("[yellow]Operating System[/]"),
-										new Markup($"[white]Name:[/] [grey]{(host.SystemName ?? "Unknown").Capitalize()}[/]"),
+										new Markup($"[white]Name:[/] [grey]{(hostInfo.SystemName ?? "Unknown").Capitalize()}[/]"),
 										new Markup($"[white]Version:[/] [grey]{systemVersion}[/]")
 									)
 								).Expand(),
@@ -103,19 +83,19 @@ namespace OceanApocalypseStudios.RSML.CLI.Helpers
 									new Rows(
 										new Markup(
 											"[green]Linux Distribution[/] [grey](if applicable)[/]",
-											host.IsLinux
+											hostInfo.IsLinux
 												? null
 												: new(null, null, Decoration.Strikethrough)
 										),
 										new Markup(
-											$"[white]Family:[/] [grey]{(host.DistroFamily ?? "Unknown").Capitalize()}[/]",
-											host.IsLinux
+											$"[white]Family:[/] [grey]{(hostInfo.DistroFamily ?? "Unknown").Capitalize()}[/]",
+											hostInfo.IsLinux
 												? null
 												: new(null, null, Decoration.Strikethrough)
 										),
 										new Markup(
-											$"[white]Name:[/] [grey]{(host.DistroName ?? "Unknown").Capitalize()}[/]",
-											host.IsLinux
+											$"[white]Name:[/] [grey]{(hostInfo.DistroName ?? "Unknown").Capitalize()}[/]",
+											hostInfo.IsLinux
 												? null
 												: new(null, null, Decoration.Strikethrough)
 										)
@@ -126,7 +106,7 @@ namespace OceanApocalypseStudios.RSML.CLI.Helpers
 						new Panel(
 							new Rows(
 								new Markup("[cyan]Processor[/]"),
-								new Markup($"[white]Architecture:[/] [grey]{host.ProcessorArchitecture ?? "Unknown"}[/]")
+								new Markup($"[white]Architecture:[/] [grey]{hostInfo.ProcessorArchitecture ?? "Unknown"}[/]")
 							)
 						).Expand()
 					)
@@ -135,71 +115,7 @@ namespace OceanApocalypseStudios.RSML.CLI.Helpers
 
 		}
 
-		public static Host FromJson(string? json)
-		{
-
-			if (json is null)
-				return new();
-
-			using var document = JsonDocument.Parse(json);
-
-			string? systemName = null!;
-			int systemVersion = -1;
-
-			string? distroName = null!;
-			string? distroFamily = null!;
-
-			string? processorArchitecture = null!;
-
-			if (document.RootElement.TryGetProperty("system", out var system))
-			{
-
-				if (system.TryGetProperty("name", out var systemNameProperty))
-					systemName = systemNameProperty.GetString();
-
-				if (system.TryGetProperty("version", out var systemVersionProperty) && systemVersionProperty.TryGetInt32(out systemVersion)) { }
-
-			}
-
-			if (document.RootElement.TryGetProperty("linuxDistro", out var linuxDistro))
-			{
-
-				if (linuxDistro.TryGetProperty("name", out var distroNameProperty))
-					distroName = distroNameProperty.GetString();
-
-				if (linuxDistro.TryGetProperty("family", out var distroFamilyProperty))
-					distroFamily = distroFamilyProperty.GetString();
-
-			}
-
-			if (document.RootElement.TryGetProperty("processor", out var processor))
-			{
-
-				if (processor.TryGetProperty("architecture", out var processorArchitectureProperty))
-					processorArchitecture = processorArchitectureProperty.GetString();
-
-			}
-
-			if (systemName is not null && systemName.Equals("linux", StringComparison.OrdinalIgnoreCase))
-			{
-
-				return new(
-					distroName,
-					distroFamily,
-					processorArchitecture,
-					systemVersion
-				);
-
-			}
-
-			return new(systemName, processorArchitecture, systemVersion);
-
-		}
-
-		private static string Quote(string? str) =>
-			str is null or "null"
-				? "null"
-				: $"\"{str}\"";
+		public static HostInfo FromJson(string? json) => json is null ? new() : (HostInfoConverter.FromJson(json) ?? new());
 
 	}
 

--- a/src/RSML.CLI/Program.Commands.cs
+++ b/src/RSML.CLI/Program.Commands.cs
@@ -7,6 +7,7 @@ using OceanApocalypseStudios.RSML.Analyzer.Syntax;
 using OceanApocalypseStudios.RSML.CLI.Helpers;
 using OceanApocalypseStudios.RSML.Evaluation;
 using OceanApocalypseStudios.RSML.Exceptions;
+using OceanApocalypseStudios.RSML.Host;
 
 using Spectre.Console;
 
@@ -74,14 +75,14 @@ namespace OceanApocalypseStudios.RSML.CLI
 
 		public static void Evaluate_NoPretty(
 			string data,
-			Host host
+			HostInfo hostInfo
 		)
 		{
 
 			try
 			{
 
-				Console.WriteLine(new Evaluator(data).Evaluate(host).MatchValue);
+				Console.WriteLine(new Evaluator(data).Evaluate(hostInfo).MatchValue);
 
 			}
 			catch (InvalidRsmlSyntax ex)
@@ -101,7 +102,7 @@ namespace OceanApocalypseStudios.RSML.CLI
 
 		public static void Evaluate_Pretty(
 			string data,
-			Host host
+			HostInfo hostInfo
 		)
 		{
 
@@ -110,7 +111,7 @@ namespace OceanApocalypseStudios.RSML.CLI
 
 			try
 			{
-				result = evaluator.Evaluate(host);
+				result = evaluator.Evaluate(hostInfo);
 			}
 			catch (UserRaisedException)
 			{
@@ -160,7 +161,7 @@ namespace OceanApocalypseStudios.RSML.CLI
 		}
 
 		public static int GetMachine(
-			Host host,
+			HostInfo hostInfo,
 			bool disableAnsi,
 			string? format
 		)
@@ -169,7 +170,7 @@ namespace OceanApocalypseStudios.RSML.CLI
 			if (disableAnsi || format != "PlainText")
 			{
 
-				string? x = LocalMachineInfo_NoPretty(host, format ?? "InvalidValue");
+				string? x = LocalMachineInfo_NoPretty(hostInfo, format ?? "InvalidValue");
 
 				if (x is not null)
 					Console.WriteLine(x);
@@ -181,7 +182,7 @@ namespace OceanApocalypseStudios.RSML.CLI
 			}
 
 			if (format == "PlainText")
-				LocalMachineInfo_Pretty(host); // eh eh
+				LocalMachineInfo_Pretty(hostInfo); // eh eh
 			else
 				return 1;
 
@@ -190,20 +191,20 @@ namespace OceanApocalypseStudios.RSML.CLI
 		}
 
 		public static string? LocalMachineInfo_NoPretty(
-			Host host,
+			HostInfo hostInfo,
 			string outputFormat
 		) =>
 			outputFormat switch
 			{
 
-				"PlainText" => HostOutput.AsPlainText(host),
-				"JSON"      => HostOutput.AsJson(host),
-				"Dotnet"    => HostOutput.AsDotnet(host),
+				"PlainText" => HostOutput.AsPlainText(hostInfo),
+				"JSON"      => HostOutput.AsJson(hostInfo),
+				"Dotnet"    => HostOutput.AsDotnet(hostInfo),
 				_           => null
 
 			};
 
-		public static void LocalMachineInfo_Pretty(Host host) => HostOutput.AsPrettyText(host);
+		public static void LocalMachineInfo_Pretty(HostInfo hostInfo) => HostOutput.AsPrettyText(hostInfo);
 
 		public static int SpecificationSupport_NoPretty()
 		{

--- a/src/RSML.CLI/Program.cs
+++ b/src/RSML.CLI/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using OceanApocalypseStudios.RSML.CLI.Helpers;
+using OceanApocalypseStudios.RSML.Host;
 
 using Spectre.Console;
 
@@ -403,12 +404,12 @@ namespace OceanApocalypseStudios.RSML.CLI
 									  ? Console.In.ReadToEnd()
 									  : File.ReadAllText(filepath);
 
-					Host host;
+					HostInfo hostInfo;
 
 					try
 					{
 
-						host = HostOutput.FromJson(result.GetValue(hostOpt));
+						hostInfo = HostOutput.FromJson(result.GetValue(hostOpt));
 
 					}
 					catch (Exception ex)
@@ -417,16 +418,16 @@ namespace OceanApocalypseStudios.RSML.CLI
 						if (disableAnsi)
 							Console.WriteLine($"JSON Error: {ex.Message}");
 						else
-							AnsiConsole.Markup($"[red]JSON Error on Host load[/] {ex.Message}");
+							AnsiConsole.Markup($"[red]JSON Error on HostInfo load[/] {ex.Message}");
 
 						return 2; // json error
 
 					}
 
 					if (disableAnsi)
-						Evaluate_NoPretty(data, host);
+						Evaluate_NoPretty(data, hostInfo);
 					else
-						Evaluate_Pretty(data, host);
+						Evaluate_Pretty(data, hostInfo);
 
 					return 0;
 

--- a/src/RSML.Native/Exports.Toolchain.cs
+++ b/src/RSML.Native/Exports.Toolchain.cs
@@ -6,6 +6,7 @@ using OceanApocalypseStudios.RSML.Analyzer.Semantics;
 using OceanApocalypseStudios.RSML.Analyzer.Syntax;
 using OceanApocalypseStudios.RSML.Evaluation;
 using OceanApocalypseStudios.RSML.Exceptions;
+using OceanApocalypseStudios.RSML.Host;
 using OceanApocalypseStudios.RSML.Native.Structures;
 
 
@@ -103,7 +104,7 @@ namespace OceanApocalypseStudios.RSML.Native
 
 				};
 
-				Host customHost =
+				HostInfo customHost =
 					systemOrDistroName is (>= 101 and <= 104) or 3
 						? new(
 							actualSystemName,
@@ -117,9 +118,9 @@ namespace OceanApocalypseStudios.RSML.Native
 							systemOrDistroMajorVersion
 						);
 
-				Host actualHost =
+				HostInfo actualHost =
 					currentHostFallback == 1
-						? Host.MergeWithFallback(customHost, Host.CurrentHost)
+						? HostInfo.MergeWithFallback(customHost, HostInfo.CurrentHost)
 						: customHost;
 
 				#endregion

--- a/src/RSML/Analyzer/Semantics/Normalizer.cs
+++ b/src/RSML/Analyzer/Semantics/Normalizer.cs
@@ -10,7 +10,7 @@ namespace OceanApocalypseStudios.RSML.Analyzer.Semantics
 	/// <summary>
 	/// The official RSML normalizer.
 	/// </summary>
-	public sealed class Normalizer : INormalizer
+	public class Normalizer : INormalizer
 	{
 
 		/// <summary>

--- a/src/RSML/Analyzer/Semantics/Validator.cs
+++ b/src/RSML/Analyzer/Semantics/Validator.cs
@@ -12,7 +12,7 @@ namespace OceanApocalypseStudios.RSML.Analyzer.Semantics
 	/// <summary>
 	/// The officially maintained semantics validator for RSML.
 	/// </summary>
-	public sealed class Validator : IValidator
+	public class Validator : IValidator
 	{
 
 		/// <inheritdoc />

--- a/src/RSML/Analyzer/Syntax/Lexer.cs
+++ b/src/RSML/Analyzer/Syntax/Lexer.cs
@@ -9,7 +9,7 @@ namespace OceanApocalypseStudios.RSML.Analyzer.Syntax
 	/// <summary>
 	/// The officially maintained lexer/tokenizer for RSML v2.0.0.
 	/// </summary>
-	public sealed class Lexer : ILexer
+	public class Lexer : ILexer
 	{
 
 		/// <inheritdoc />

--- a/src/RSML/Analyzer/Syntax/SyntaxLine.cs
+++ b/src/RSML/Analyzer/Syntax/SyntaxLine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -9,7 +10,7 @@ namespace OceanApocalypseStudios.RSML.Analyzer.Syntax
 	/// <summary>
 	/// A performant syntax line.
 	/// </summary>
-	public struct SyntaxLine
+	public struct SyntaxLine : IEnumerable<SyntaxToken>, IEquatable<SyntaxLine>
 	{
 
 		/// <summary>
@@ -644,6 +645,37 @@ namespace OceanApocalypseStudios.RSML.Analyzer.Syntax
 			return tokens;
 
 		}
+
+		internal struct TokenEnumerator(SyntaxLine line) : IEnumerator<SyntaxToken>
+		{
+
+			private int index = -1;
+
+			public readonly SyntaxToken Current => line[index];
+
+			readonly object IEnumerator.Current => Current;
+
+			public void Dispose() => Reset();
+
+			public bool MoveNext()
+			{
+
+				if (index + 1 >= 8)
+					return false;
+
+				index++;
+				return true;
+
+			}
+
+			public void Reset() => index = -1;
+
+		}
+
+		/// <inheritdoc/>
+		public readonly IEnumerator<SyntaxToken> GetEnumerator() => new TokenEnumerator(this);
+
+		readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	}
 

--- a/src/RSML/Evaluation/Evaluator.cs
+++ b/src/RSML/Evaluation/Evaluator.cs
@@ -40,6 +40,7 @@ using OceanApocalypseStudios.RSML.Analyzer;
 using OceanApocalypseStudios.RSML.Analyzer.Semantics;
 using OceanApocalypseStudios.RSML.Analyzer.Syntax;
 using OceanApocalypseStudios.RSML.Exceptions;
+using OceanApocalypseStudios.RSML.Host;
 using OceanApocalypseStudios.RSML.Toolchain.Compliance;
 
 
@@ -104,7 +105,7 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 		public EvaluationResult Evaluate() => Evaluate(new());
 
 		/// <inheritdoc />
-		public EvaluationResult Evaluate(Host host)
+		public EvaluationResult Evaluate(HostInfo hostInfo)
 		{
 
 			if (Content.Length == 0)
@@ -179,8 +180,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 						if (HandleLogicPath_Simple(
 								tokens,
 								Content,
-								host,
-								host.IsLinux
+								hostInfo,
+								hostInfo.IsLinux
 							))
 						{
 
@@ -196,8 +197,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 						if (HandleLogicPath_Complex(
 								tokens,
 								Content,
-								host,
-								host.IsLinux
+								hostInfo,
+								hostInfo.IsLinux
 							))
 						{
 
@@ -230,20 +231,20 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 		private static bool HandleLogicPath_Complex(
 			SyntaxLine tokens,
 			DualTextBuffer context,
-			in Host host,
+			in HostInfo hostInfo,
 			bool isLinux
 		)
 		{
 
 			if (isLinux)
-				return HandleLogicPath_Complex_Linux(tokens, context, host);
+				return HandleLogicPath_Complex_Linux(tokens, context, hostInfo);
 
 			bool systemNameMatches = tokens[1].Kind switch
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.SystemName is not null,
-				_                         => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.SystemName)
+				TokenKind.DefinedKeyword  => hostInfo.SystemName is not null,
+				_                         => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.SystemName)
 
 			};
 
@@ -255,36 +256,36 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				case TokenKind.EqualTo:
-					systemVersionMatches = context[tokens[3].BufferRange].IsEquals(host.StringifiedSystemVersion);
+					systemVersionMatches = context[tokens[3].BufferRange].IsEquals(hostInfo.StringifiedSystemVersion);
 
 					break;
 
 				case TokenKind.NotEqualTo:
-					systemVersionMatches = !context[tokens[3].BufferRange].IsEquals(host.StringifiedSystemVersion);
+					systemVersionMatches = !context[tokens[3].BufferRange].IsEquals(hostInfo.StringifiedSystemVersion);
 
 					break;
 
 				case TokenKind.GreaterThanOrEqualTo:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion >= versionNum;
+						systemVersionMatches = hostInfo.SystemVersion >= versionNum;
 
 					break;
 
 				case TokenKind.LessThanOrEqualTo:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion <= versionNum;
+						systemVersionMatches = hostInfo.SystemVersion <= versionNum;
 
 					break;
 
 				case TokenKind.GreaterThan:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion > versionNum;
+						systemVersionMatches = hostInfo.SystemVersion > versionNum;
 
 					break;
 
 				case TokenKind.LessThan:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion < versionNum;
+						systemVersionMatches = hostInfo.SystemVersion < versionNum;
 
 					break;
 
@@ -299,8 +300,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.ProcessorArchitecture is not null,
-				_                         => context[tokens[4].BufferRange].IsAsciiEqualsIgnoreCase(host.StringifiedSystemVersion)
+				TokenKind.DefinedKeyword  => hostInfo.ProcessorArchitecture is not null,
+				_                         => context[tokens[4].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.StringifiedSystemVersion)
 
 			};
 
@@ -311,7 +312,7 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 		private static bool HandleLogicPath_Complex_Linux(
 			SyntaxLine tokens,
 			DualTextBuffer context,
-			in Host host
+			in HostInfo hostInfo
 		)
 		{
 
@@ -319,10 +320,10 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.DistroName is not null,
-				_ => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.SystemName) ||
-					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.DistroName) ||
-					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.DistroFamily)
+				TokenKind.DefinedKeyword  => hostInfo.DistroName is not null,
+				_ => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.SystemName) ||
+					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.DistroName) ||
+					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.DistroFamily)
 
 			};
 
@@ -334,36 +335,36 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				case TokenKind.EqualTo:
-					systemVersionMatches = context[tokens[3].BufferRange].IsEquals(host.StringifiedSystemVersion);
+					systemVersionMatches = context[tokens[3].BufferRange].IsEquals(hostInfo.StringifiedSystemVersion);
 
 					break;
 
 				case TokenKind.NotEqualTo:
-					systemVersionMatches = !context[tokens[3].BufferRange].IsEquals(host.StringifiedSystemVersion);
+					systemVersionMatches = !context[tokens[3].BufferRange].IsEquals(hostInfo.StringifiedSystemVersion);
 
 					break;
 
 				case TokenKind.GreaterThanOrEqualTo:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion >= versionNum;
+						systemVersionMatches = hostInfo.SystemVersion >= versionNum;
 
 					break;
 
 				case TokenKind.LessThanOrEqualTo:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion <= versionNum;
+						systemVersionMatches = hostInfo.SystemVersion <= versionNum;
 
 					break;
 
 				case TokenKind.GreaterThan:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion > versionNum;
+						systemVersionMatches = hostInfo.SystemVersion > versionNum;
 
 					break;
 
 				case TokenKind.LessThan:
 					if (Int32.TryParse(context[tokens[3].BufferRange].Span, out versionNum))
-						systemVersionMatches = host.SystemVersion < versionNum;
+						systemVersionMatches = hostInfo.SystemVersion < versionNum;
 
 					break;
 
@@ -379,8 +380,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.ProcessorArchitecture is not null,
-				_                         => context[tokens[4].BufferRange].IsAsciiEqualsIgnoreCase(host.ProcessorArchitecture)
+				TokenKind.DefinedKeyword  => hostInfo.ProcessorArchitecture is not null,
+				_                         => context[tokens[4].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.ProcessorArchitecture)
 
 			};
 
@@ -391,20 +392,20 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 		private static bool HandleLogicPath_Simple(
 			SyntaxLine tokens,
 			DualTextBuffer context,
-			in Host host,
+			in HostInfo hostInfo,
 			bool isLinux
 		)
 		{
 
 			if (isLinux)
-				return HandleLogicPath_Simple_Linux(tokens, context, host);
+				return HandleLogicPath_Simple_Linux(tokens, context, hostInfo);
 
 			bool systemNameMatches = tokens[1].Kind switch
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.SystemName is not null,
-				_                         => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.SystemName)
+				TokenKind.DefinedKeyword  => hostInfo.SystemName is not null,
+				_                         => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.SystemName)
 
 			};
 
@@ -412,8 +413,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.SystemVersion != -1,
-				_                         => context[tokens[2].BufferRange].IsEquals(host.StringifiedSystemVersion)
+				TokenKind.DefinedKeyword  => hostInfo.SystemVersion != -1,
+				_                         => context[tokens[2].BufferRange].IsEquals(hostInfo.StringifiedSystemVersion)
 
 			};
 
@@ -421,8 +422,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.ProcessorArchitecture is not null,
-				_                         => context[tokens[3].BufferRange].IsAsciiEqualsIgnoreCase(host.ProcessorArchitecture)
+				TokenKind.DefinedKeyword  => hostInfo.ProcessorArchitecture is not null,
+				_                         => context[tokens[3].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.ProcessorArchitecture)
 
 			};
 
@@ -433,7 +434,7 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 		private static bool HandleLogicPath_Simple_Linux(
 			SyntaxLine tokens,
 			DualTextBuffer context,
-			in Host host
+			in HostInfo hostInfo
 		)
 		{
 
@@ -441,10 +442,10 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.DistroName is not null,
-				_ => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.SystemName) ||
-					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.DistroName) ||
-					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(host.DistroFamily)
+				TokenKind.DefinedKeyword  => hostInfo.DistroName is not null,
+				_ => context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.SystemName) ||
+					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.DistroName) ||
+					 context[tokens[1].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.DistroFamily)
 
 			};
 
@@ -452,8 +453,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.SystemVersion != -1,
-				_                         => context[tokens[2].BufferRange].IsEquals(host.StringifiedSystemVersion)
+				TokenKind.DefinedKeyword  => hostInfo.SystemVersion != -1,
+				_                         => context[tokens[2].BufferRange].IsEquals(hostInfo.StringifiedSystemVersion)
 
 			};
 
@@ -461,8 +462,8 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 			{
 
 				TokenKind.WildcardKeyword => true,
-				TokenKind.DefinedKeyword  => host.ProcessorArchitecture is not null,
-				_                         => context[tokens[3].BufferRange].IsAsciiEqualsIgnoreCase(host.ProcessorArchitecture)
+				TokenKind.DefinedKeyword  => hostInfo.ProcessorArchitecture is not null,
+				_                         => context[tokens[3].BufferRange].IsAsciiEqualsIgnoreCase(hostInfo.ProcessorArchitecture)
 
 			};
 

--- a/src/RSML/Evaluation/IEvaluator.cs
+++ b/src/RSML/Evaluation/IEvaluator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using OceanApocalypseStudios.RSML.Analyzer;
+using OceanApocalypseStudios.RSML.Host;
 using OceanApocalypseStudios.RSML.Toolchain;
 
 
@@ -41,9 +42,9 @@ namespace OceanApocalypseStudios.RSML.Evaluation
 		/// <summary>
 		/// Evaluates the RSML document with the specified host's data.
 		/// </summary>
-		/// <param name="host">The host data</param>
+		/// <param name="hostInfo">The host data</param>
 		/// <returns>A result</returns>
-		EvaluationResult Evaluate(Host host);
+		EvaluationResult Evaluate(HostInfo hostInfo);
 
 	}
 

--- a/src/RSML/GlobalSuppressions.cs
+++ b/src/RSML/GlobalSuppressions.cs
@@ -71,3 +71,6 @@ using System.Diagnostics.CodeAnalysis;
 		Scope = "member",
 		Target = "~M:OceanApocalypseStudios.RSML.Analyzer.Syntax.SyntaxLine.Add(OceanApocalypseStudios.RSML.Analyzer.Syntax.SyntaxToken)"
 	)]
+[assembly: SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "<Pending>", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.Host.HostInfoConverter.FromJson(System.Text.Json.JsonDocument,System.Text.Json.JsonSerializerOptions)~System.Nullable{OceanApocalypseStudios.RSML.Host.HostInfo}")]
+[assembly: SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "<Pending>", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.Host.HostInfo.Equals(System.Object)~System.Boolean")]
+[assembly: SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "<Pending>", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.Host.HostInfoConverter.FromJson(System.ReadOnlySpan{System.Char},System.Text.Json.JsonSerializerOptions)~System.Nullable{OceanApocalypseStudios.RSML.Host.HostInfo}")]

--- a/src/RSML/Host/HostConverter.cs
+++ b/src/RSML/Host/HostConverter.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.ComponentModel;
+using System.Text.Json;
+
+
+namespace OceanApocalypseStudios.RSML.Host
+{
+
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	internal sealed class HostInfoWire
+	{
+
+		public string? SystemName { get; set; }
+		public int SystemVersion { get; set; }
+		public string? DistroName { get; set; }
+		public string? DistroFamily { get; set; }
+		public string? ProcessorArchitecture { get; set; }
+
+	}
+
+	/// <summary>
+	/// JSON &lt;-&gt; <see cref="HostInfo"/> converter that respects the
+	/// <a href="https://github.com/OceanApocalypseStudios/schemas/blob/main/rsml_hostinfo_schema.json">official</a>
+	/// schema.
+	/// </summary>
+	public static class HostInfoConverter
+	{
+
+		/// <summary>
+		/// Converts JSON into <see cref="HostInfo"/>.
+		/// </summary>
+		/// <param name="document">The JSON document</param>
+		/// <param name="options">Serialization options</param>
+		/// <returns>The host's info</returns>
+		public static HostInfo? FromJson(ReadOnlySpan<char> document, JsonSerializerOptions? options = null)
+		{
+
+			var wire = JsonSerializer.Deserialize<HostInfoWire>(document, options);
+
+			if (wire is null)
+				return null;
+
+			if (wire.SystemName == "linux")
+				return new(wire.DistroName, wire.DistroFamily, wire.ProcessorArchitecture, wire.SystemVersion);
+
+			return new(wire.SystemName, wire.ProcessorArchitecture, wire.SystemVersion);
+
+		}
+
+		/// <inheritdoc cref="FromJson(ReadOnlySpan{Char}, JsonSerializerOptions?)"/>
+		public static HostInfo? FromJson(string document, JsonSerializerOptions? options = null) => FromJson(document.AsSpan(), options);
+
+		/// <inheritdoc cref="FromJson(ReadOnlySpan{Char}, JsonSerializerOptions?)"/>
+		public static HostInfo? FromJson(JsonDocument document, JsonSerializerOptions? options = null)
+		{
+
+			var wire = JsonSerializer.Deserialize<HostInfoWire>(document, options);
+
+			if (wire is null)
+				return null;
+
+			if (wire.SystemName == "linux")
+				return new(wire.DistroName, wire.DistroFamily, wire.ProcessorArchitecture, wire.SystemVersion);
+
+			return new(wire.SystemName, wire.ProcessorArchitecture, wire.SystemVersion);
+
+		}
+
+		/// <summary>
+		/// Converts <see cref="HostInfo"/> into JSON.
+		/// </summary>
+		/// <param name="hostInfo">The host's info</param>
+		/// <returns>The JSON string</returns>
+		public static string ToJson(HostInfo hostInfo) =>
+			$$"""
+			{
+				"SystemName": "{{hostInfo.SystemName ?? "null"}}",
+				"SystemVersion": {{hostInfo.SystemVersion}},
+				"DistroName": "{{hostInfo.DistroName ?? "null"}}",
+				"DistroFamily": "{{hostInfo.DistroFamily ?? "null"}}",
+				"ProcessorArchitecture": "{{hostInfo.ProcessorArchitecture ?? "null"}}"
+			}
+			""";
+
+	}
+
+}

--- a/src/RSML/Host/HostInfo.Windows.cs
+++ b/src/RSML/Host/HostInfo.Windows.cs
@@ -6,11 +6,11 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32;
 
 
-namespace OceanApocalypseStudios.RSML
+namespace OceanApocalypseStudios.RSML.Host
 {
 
 	[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")] // this only compiles on windows there's no problem
-	public partial struct Host
+	public partial struct HostInfo
 	{
 
 		private void InitializeVersionData_Windows()

--- a/src/RSML/Host/HostInfo.cs
+++ b/src/RSML/Host/HostInfo.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 
 
-// ReSharper disable UnusedAutoPropertyAccessor.Global
-
-namespace OceanApocalypseStudios.RSML
+namespace OceanApocalypseStudios.RSML.Host
 {
 
 	/// <summary>
 	/// A representation of several attributes of an host.
 	/// </summary>
-	public partial struct Host
+	public partial struct HostInfo : IEquatable<HostInfo>
 	{
 
 		/// <summary>
 		/// Collects data from the system and creates a new instance of the struct.
 		/// </summary>
-		public Host()
+		public HostInfo()
 		{
 
 			InitializeSystemName();
@@ -37,7 +36,7 @@ namespace OceanApocalypseStudios.RSML
 		/// <param name="osName">The OS name or null if undefined</param>
 		/// <param name="processorArchitecture">The processor architecture or null if undefined</param>
 		/// <param name="osMajorVersion">The OS's major version or null or -1 if undefined</param>
-		public Host(
+		public HostInfo(
 			string? osName,
 			string? processorArchitecture,
 			int? osMajorVersion
@@ -57,7 +56,7 @@ namespace OceanApocalypseStudios.RSML
 		/// <param name="distroFamily">The distro's family or null if undefined</param>
 		/// <param name="processorArchitecture">The processor architecture or null if undefined</param>
 		/// <param name="distroMajorVersion">The OS's major version or null or -1 if undefined</param>
-		public Host(
+		public HostInfo(
 			string? distroName,
 			string? distroFamily,
 			string? processorArchitecture,
@@ -76,7 +75,7 @@ namespace OceanApocalypseStudios.RSML
 		/// <summary>
 		/// The host RSML is running on.
 		/// </summary>
-		public static Host CurrentHost => new();
+		public static HostInfo CurrentHost => new();
 
 		/// <summary>
 		/// The name of the Linux distribution or <c>null</c> if undetected or not Linux.
@@ -128,36 +127,15 @@ namespace OceanApocalypseStudios.RSML
 		public int SystemVersion { get; private set; } = -1;
 
 		/// <summary>
-		/// Creates a new struct of system attributes for a Linux distribution.
-		/// </summary>
-		/// <param name="distroName">The distro's name or null if undefined</param>
-		/// <param name="distroFamily">The distro's family or null if undefined</param>
-		/// <param name="processorArchitecture">The processor architecture or null if undefined</param>
-		/// <param name="distroMajorVersion">The OS's major version or null or -1 if undefined</param>
-		[Obsolete("Use Host(string?, string?, string?, int?) instead")]
-		public static Host Linux(
-			string? distroName,
-			string? distroFamily,
-			string? processorArchitecture,
-			int? distroMajorVersion
-		) =>
-			new(
-				distroName,
-				distroFamily,
-				processorArchitecture,
-				distroMajorVersion
-			);
-
-		/// <summary>
-		/// Merges two <see cref="Host" /> instances,
+		/// Merges two <see cref="HostInfo" /> instances,
 		/// using the latter as fallback for the first.
 		/// </summary>
 		/// <param name="main">The host whose non-null attributes are used over the fallback's</param>
 		/// <param name="fallback">The host that serves as the fallback for <paramref name="main" />'s null attributes</param>
-		/// <returns>A new instance of a <see cref="Host" /></returns>
-		public static Host MergeWithFallback(
-			Host main,
-			Host fallback
+		/// <returns>A new instance of a <see cref="HostInfo" /></returns>
+		public static HostInfo MergeWithFallback(
+			HostInfo main,
+			HostInfo fallback
 		) =>
 			main.SystemName.IsAsciiEqualsIgnoreCase("linux") || main.DistroName is not null || main.DistroFamily is not null
 				? new(
@@ -176,21 +154,60 @@ namespace OceanApocalypseStudios.RSML
 						: -1
 				);
 
+		/// <inheritdoc/>
+		public readonly override bool Equals([NotNullWhen(true)] object? obj)
+		{
+
+			if (obj is HostInfo hostInfo)
+				return Equals(hostInfo);
+
+			return false;
+
+		}
+
 		/// <summary>
-		/// Merges an instance of <see cref="Host" /> with
+		/// Checks whether two instances of <see cref="HostInfo"/> are equal to each other.
+		/// </summary>
+		/// <param name="other">The instance to check against</param>
+		/// <returns>True if equals</returns>
+		public readonly bool Equals(HostInfo other) =>
+			SystemName == other.SystemName &&
+			DistroName == other.DistroName &&
+			DistroFamily == other.DistroFamily &&
+			ProcessorArchitecture == other.ProcessorArchitecture &&
+			SystemVersion == other.SystemVersion;
+
+		/// <summary>
+		/// Checks whether two instances of <see cref="HostInfo"/> are equal to each other.
+		/// </summary>
+		/// <param name="left"></param>
+		/// <param name="right"></param>
+		/// <returns>True if equals</returns>
+		public static bool operator ==(HostInfo left, HostInfo right) => left.Equals(right);
+
+		/// <summary>
+		/// Checks whether two instances of <see cref="HostInfo"/> are different from each other.
+		/// </summary>
+		/// <param name="left"></param>
+		/// <param name="right"></param>
+		/// <returns>True if equals</returns>
+		public static bool operator !=(HostInfo left, HostInfo right) => !left.Equals(right);
+
+		/// <summary>
+		/// Merges an instance of <see cref="HostInfo" /> with
 		/// this one, which is treated as a fallback.
 		/// </summary>
 		/// <param name="main">The host whose non-null attributes are used over this instance's</param>
-		/// <returns>A new instance of a <see cref="Host" /></returns>
-		public readonly Host MergeAsFallback(Host main) => MergeWithFallback(main, this);
+		/// <returns>A new instance of a <see cref="HostInfo" /></returns>
+		public readonly HostInfo MergeAsFallback(HostInfo main) => MergeWithFallback(main, this);
 
 		/// <summary>
-		/// Merges this <see cref="Host" /> instance
+		/// Merges this <see cref="HostInfo" /> instance
 		/// with another one, which is treated as a fallback.
 		/// </summary>
 		/// <param name="fallback">The host that serves as the fallback for this instance's null attributes</param>
-		/// <returns>A new instance of a <see cref="Host" /></returns>
-		public readonly Host MergeWithFallback(Host fallback) => MergeWithFallback(this, fallback);
+		/// <returns>A new instance of a <see cref="HostInfo" /></returns>
+		public readonly HostInfo MergeWithFallback(HostInfo fallback) => MergeWithFallback(this, fallback);
 
 		internal void InitializeVersionData_FreeBsd()
 		{
@@ -350,6 +367,10 @@ namespace OceanApocalypseStudios.RSML
 
 		}
 
+		public override int GetHashCode()
+		{
+			throw new NotImplementedException();
+		}
 	}
 
 }

--- a/tests/EvaluatorTests.cs
+++ b/tests/EvaluatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using OceanApocalypseStudios.RSML.Evaluation;
 using OceanApocalypseStudios.RSML.Exceptions;
+using OceanApocalypseStudios.RSML.Host;
 
 
 namespace OceanApocalypseStudios.RSML.Tests
@@ -139,23 +140,23 @@ namespace OceanApocalypseStudios.RSML.Tests
 		[InlineData("                                            #")]
 		public void Evaluator_IsComment(string input) => Assert.True(Evaluator.IsComment(input));
 
-		private static readonly Host debianUnknownVersionX86 = new(
+		private static readonly HostInfo debianUnknownVersionX86 = new(
 			"debian",
 			"debian",
 			"x86",
 			null
 		);
 
-		private static readonly Host osxUnknownVersionUnknownArch = new("osx", null, null);
+		private static readonly HostInfo osxUnknownVersionUnknownArch = new("osx", null, null);
 
-		private static readonly Host ubuntu22Arm64 = new(
+		private static readonly HostInfo ubuntu22Arm64 = new(
 			"ubuntu",
 			"debian",
 			"x64",
 			22
 		);
 
-		private static readonly Host win10X64 = new("windows", "x64", 10);
+		private static readonly HostInfo win10X64 = new("windows", "x64", 10);
 
 	}
 

--- a/tests/NativeTests.rsml_evaluate_document.cs
+++ b/tests/NativeTests.rsml_evaluate_document.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 
 using OceanApocalypseStudios.RSML.Evaluation;
+using OceanApocalypseStudios.RSML.Host;
 using OceanApocalypseStudios.RSML.Native.Structures;
 
 
@@ -193,7 +194,7 @@ namespace OceanApocalypseStudios.RSML.Tests
 
 		}
 
-		private static readonly Host ubuntu22Arm64 = new(
+		private static readonly HostInfo ubuntu22Arm64 = new(
 			"ubuntu",
 			"debian",
 			"x64",

--- a/tests/StructureTests.cs
+++ b/tests/StructureTests.cs
@@ -1,0 +1,85 @@
+﻿using System.Linq;
+
+using OceanApocalypseStudios.RSML.Analyzer.Syntax;
+using OceanApocalypseStudios.RSML.Host;
+
+
+namespace OceanApocalypseStudios.RSML.Tests
+{
+
+	public class StructureTests
+	{
+
+		[Fact]
+		public void SyntaxLine_GetEnumerator()
+		{
+
+			int x = -1;
+			SyntaxLine line = new(
+				new(TokenKind.SystemName, 0, 2),
+				new(TokenKind.SystemName, 4, 9),
+				new(TokenKind.SystemName, 11, 13),
+				new(TokenKind.SystemName, 14, 19),
+				new(TokenKind.SystemName, 22, 25),
+				new(TokenKind.SystemName, 37, 44),
+				SyntaxToken.Empty,
+				SyntaxToken.Empty
+			);
+
+			foreach (var token in line)
+			{
+
+				Assert.True(token == line[++x]);
+				Assert.True(token == line.ElementAt(x));
+
+			}
+
+		}
+
+		[Fact]
+		public void HostInfo_FromJson()
+		{
+
+			string jsonString =
+				"""
+				{
+					"SystemName": "linux",
+					"SystemVersion": 22,
+					"ProcessorArchitecture": "x86",
+					"DistroName": "ubuntu",
+					"DistroFamily": "debian"
+				}
+				""";
+
+			var actual = HostInfoConverter.FromJson(jsonString);
+			HostInfo expected = new("ubuntu", "debian", "x86", 22);
+
+			Assert.True(expected.Equals(actual));
+
+		}
+
+		[Fact]
+		public void HostInfo_ToJson()
+		{
+
+			string expected =
+				"""
+				{
+					"SystemName": "linux",
+					"SystemVersion": 22,
+					"DistroName": "ubuntu",
+					"DistroFamily": "debian",
+					"ProcessorArchitecture": "x86"
+				}
+				""";
+
+			HostInfo hostInfo = new("ubuntu", "debian", "x86", 22);
+			var actual = HostInfoConverter.ToJson(hostInfo);
+
+			Assert.Equal(expected, actual);
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Rename `Host` to `HostInfo`
- Add a converter for JSON <=> `HostInfo`
- Move to the new `HostInfo` JSON schema
- Inherit from interfaces and abstract classes when applicable