### PR TITLE
Add and test `TryGetLineFromIndex` method to the read-only string buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the modern language designed to dynamically interpret different logic paths base
 ## Contents
 - [Red Sea Markup Language (RSML)](#section)
 	- [Why RSML?](#why-rsml)
-    - [How to build RSML?](#how-to-build-rsml)
+	- [How to build RSML?](#how-to-build-rsml)
 
 <details open>
 <summary><strong>Where's the "How to use" section?</strong></summary>
@@ -44,7 +44,8 @@ You can find full documentation [here](https://oceanapocalypsestudios.org/rsml-d
 <details open>
 <summary><strong>How can I see what is being worked on in RSML?</strong></summary>
 
-You can find the official bug tracker and roadmap [here](https://github.com/orgs/OceanApocalypseStudios/projects/6/views/2).
+You can find the official bug tracker and
+roadmap [here](https://github.com/orgs/OceanApocalypseStudios/projects/6/views/2).
 
 </details>
 
@@ -52,8 +53,10 @@ You can find the official bug tracker and roadmap [here](https://github.com/orgs
 
 ## Why RSML?
 RSML solves the issue of resolving logic paths dynamically based on a given host's characteristics.
-When assigned an host, which could be the local host, RSML solves the logic paths and returns the first match's associated value.
-The important part here is to note RSML does this dynamically: if you were to switch hosts or pass different data, RSML would adapt accordingly.
+When assigned an host, which could be the local host, RSML solves the logic paths and returns the first match's
+associated value.
+The important part here is to note RSML does this dynamically: if you were to switch hosts or pass different data, RSML
+would adapt accordingly.
 
 **Still unsure about RSML?** You can find some usage examples [here](#examples).
 
@@ -65,7 +68,7 @@ The important part here is to note RSML does this dynamically: if you were to sw
 
 1. Clone [this repository](https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage).
 2. Open the terminal in the root RSML directory (the one with the solution file).
-	
+
 ```
 dotnet build -c Debug RedSeaMarkupLanguage.slnx
 ./src/RSML.CLI/bin/Debug/net10.0/RSML.CLI.exe
@@ -78,7 +81,7 @@ dotnet build -c Debug RedSeaMarkupLanguage.slnx
 
 1. Clone [this repository](https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage).
 2. Open the terminal in the root RSML directory (the one with the solution file).
-	
+
 ```
 dotnet build -c Release RedSeaMarkupLanguage.slnx
 ./src/RSML.CLI/bin/Release/net10.0/RSML.CLI.exe
@@ -90,16 +93,19 @@ dotnet build -c Release RedSeaMarkupLanguage.slnx
 
 1. Clone [this repository](https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage).
 2. Open the terminal in the root RSML directory (the one with the solution file).
-	
+
 ```
 dotnet publish -c Release -r <rid> src/RSML.Native/RSML.Native.csproj
 ```
 
 > [!WARNING]
 > If you're on Windows and using Visual Studio, this will require both the .NET and C++ development workloads.
-> If something goes wrong with the MSVC side of things, the fix is almost always repairing the Visual Studio installation *(backup settings and everything you need first)*.
+> If something goes wrong with the MSVC side of things, the fix is almost always repairing the Visual Studio
+> installation *(backup settings and everything you need first)*.
 
-Once that is complete, the DLL will be located at `src/RSML.Native/bin/<arch>/Release/net10.0/<rid>/publish/RSML.Native.dll`. The XML files in the same directory are purely for documentation purposes and the `.pdb` file only matters for debugging.
+Once that is complete, the DLL will be located at
+`src/RSML.Native/bin/<arch>/Release/net10.0/<rid>/publish/RSML.Native.dll`. The XML files in the same directory are
+purely for documentation purposes and the `.pdb` file only matters for debugging.
 
 </details>
 

--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 
 
-namespace OceanApocalypseStudios.RSML.Benchmarks
+namespace OceanApocalypseStudios.RSML.Benchmarks;
+
+internal class Program
 {
-
-	internal class Program
-	{
-
-		static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
-
-	}
-
+	static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
 }

--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -5,5 +5,5 @@ namespace OceanApocalypseStudios.RSML.Benchmarks;
 
 internal class Program
 {
-	static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
+	private static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
 }

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,98 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## {{ version | trim_start_matches(pat="v") }} @ {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = false
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚧 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true }, # ignore maintenance and chores
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 10 --> Other" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = true
+# Fail on a commit that is not matched by any commit parser.
+fail_on_unmatched_commit = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order commits topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false
+
+[remote.github]
+owner = "OceanApocalypseStudios"
+repo = "RedSeaMarkupLanguage"

--- a/cliff.toml
+++ b/cliff.toml
@@ -61,17 +61,17 @@ protect_breaking_commits = false
 commit_parsers = [
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },
     { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^docs", group = "<!-- 5 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 3 -->⚡ Performance" },
     { message = "^refactor", group = "<!-- 2 -->🚧 Refactor" },
-    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^style", group = "<!-- 6 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 7 -->🧪 Testing" },
     { message = "^chore\\(release\\): prepare for", skip = true }, # ignore maintenance and chores
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },
-    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^chore|^ci", group = "<!-- 8 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 4 -->🛡️ Security" },
     { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
     { message = ".*", group = "<!-- 10 --> Other" },
 ]

--- a/src/RSML.CLI/Program.cs
+++ b/src/RSML.CLI/Program.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 
 
-namespace OceanApocalypseStudios.RSML.CLI
+namespace OceanApocalypseStudios.RSML.CLI;
+
+internal class Program
 {
-
-	internal class Program
-	{
-
-		static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
-
-	}
-
+	static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
 }

--- a/src/RSML.CLI/Program.cs
+++ b/src/RSML.CLI/Program.cs
@@ -5,5 +5,5 @@ namespace OceanApocalypseStudios.RSML.CLI;
 
 internal class Program
 {
-	static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
+	private static void Main(string[] args) => Console.WriteLine("Hello, World!"); // todo
 }

--- a/src/RSML.Native/Class1.cs
+++ b/src/RSML.Native/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace OceanApocalypseStudios.RSML.Native;
+
+public class Class1
+{
+	// todo: remove this placeholder class and export native C functions
+}

--- a/src/RSML.Native/Directory.Build.props
+++ b/src/RSML.Native/Directory.Build.props
@@ -1,0 +1,20 @@
+<!-- NuGet Packaging -->
+<Project>
+	<PropertyGroup Label="NuGet Package Setup">
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+
+		<Title>RSML Native Interop</Title>
+		<PackageId>OceanApocalypseStudios.RSML.Native</PackageId>
+		<Authors>OceanApocalypseStudios</Authors>
+		<Company>OceanApocalypseStudios</Company>
+		<Description>Native C-like interopability for RSML.</Description>
+		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
+		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/2.0.0-prerelease8/</PackageProjectUrl>
+		<PackageLicenseUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/blob/v2.0.0-dev/LICENSE.txt</PackageLicenseUrl>
+		<PackageIcon>Icon.png</PackageIcon>
+		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>markup</PackageTags>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+	</PropertyGroup>
+</Project>

--- a/src/RSML.Native/Directory.Build.props
+++ b/src/RSML.Native/Directory.Build.props
@@ -3,18 +3,26 @@
 	<PropertyGroup Label="NuGet Package Setup">
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
-		<Title>RSML Native Interop</Title>
 		<PackageId>OceanApocalypseStudios.RSML.Native</PackageId>
+		<Title>RSML Native ABI</Title>
 		<Authors>OceanApocalypseStudios</Authors>
 		<Company>OceanApocalypseStudios</Company>
-		<Description>Native C-like interopability for RSML.</Description>
+		<NeutralLanguage>en</NeutralLanguage>
+
+		<!-- DON'T FORGET TO EDIT THIS -->
+		<Version>3.0.0-prerelease1</Version>
+		<InformationalVersion>3.0.0-prerelease1</InformationalVersion>
+		<PackageReleaseNotes>TODO</PackageReleaseNotes>
+		
+		<Description>Native C interopability for RSML.</Description>
 		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
 		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/2.0.0-prerelease8/</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/blob/v2.0.0-dev/LICENSE.txt</PackageLicenseUrl>
-		<PackageIcon>Icon.png</PackageIcon>
+		<PackageIcon>icon.png</PackageIcon>
 		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<PackageTags>markup</PackageTags>
+		<PackageTags>markup;native;interop;c;cpp;c++;language;logic;logic-path;rsml;rsea;decision;oss</PackageTags>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 </Project>

--- a/src/RSML.Native/RSML.Native.csproj
+++ b/src/RSML.Native/RSML.Native.csproj
@@ -15,26 +15,11 @@
 		<TieredCompilation>true</TieredCompilation>
 		<PublishSingleFile>false</PublishSingleFile>
 
-		<!-- NuGet Properties -->
-		<Title>RSML Native Interop</Title>
-		<PackageId>OceanApocalypseStudios.RSML.Native</PackageId>
-		<Authors>OceanApocalypseStudios</Authors>
-		<Company>OceanApocalypseStudios</Company>
-		<Version>2.0.0-prerelease9</Version>
-		<Description>Native C-like interopability for RSML.</Description>
-		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
-		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/2.0.0-prerelease8/</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/blob/v2.0.0-dev/LICENSE.txt</PackageLicenseUrl>
-		<PackageIcon>Icon.png</PackageIcon>
-		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageTags>markup</PackageTags>
-		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<Platforms>AnyCPU;ARM64;x64;x86</Platforms>
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
+		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/RSML.Native/RSML.Native.csproj
+++ b/src/RSML.Native/RSML.Native.csproj
@@ -18,6 +18,19 @@
 		<Platforms>AnyCPU;ARM64;x64;x86</Platforms>
 	</PropertyGroup>
 
+	<ItemGroup Label="Resources">
+		<None Include="..\..\assets\icon.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+			<Visible>false</Visible>
+		</None>
+		<None Include="..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+			<Visible>false</Visible>
+		</None>
+	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
 	</ItemGroup>

--- a/src/RSML.Sdk/Class1.cs
+++ b/src/RSML.Sdk/Class1.cs
@@ -1,7 +1,6 @@
-﻿namespace OceanApocalypseStudios.RSML.Sdk
-{
-	public class Class1
-	{
+﻿namespace OceanApocalypseStudios.RSML.Sdk;
 
-	}
+public class Class1
+{
+	// todo: remove this placeholder class and structure the RSML SDK
 }

--- a/src/RSML.Sdk/Directory.Build.props
+++ b/src/RSML.Sdk/Directory.Build.props
@@ -1,0 +1,26 @@
+<!-- NuGet Packaging -->
+<Project>
+	<PropertyGroup Label="NuGet Package Setup">
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+
+		<PackageId>OceanApocalypseStudios.RSML.Sdk</PackageId>
+		<Title>Red Sea Markup Language SDK</Title>
+		<Authors>OceanApocalypseStudios</Authors>
+		<Company>OceanApocalypseStudios</Company>
+		<NeutralLanguage>en</NeutralLanguage>
+
+		<!-- DON'T FORGET TO EDIT THIS -->
+		<PackageReleaseNotes>TODO</PackageReleaseNotes>
+
+		<Description>The plug and play SDK for the only markup language that dynamically interprets different logic paths based on an host's OS and CPU architecture.</Description>
+		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
+		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/</PackageProjectUrl>
+		<PackageIcon>icon.png</PackageIcon>
+		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>markup;language;logic;logic-path;system;host;rsml;rsea;decision;oss</PackageTags>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+</Project>

--- a/src/RSML.Sdk/Directory.Build.props
+++ b/src/RSML.Sdk/Directory.Build.props
@@ -10,6 +10,8 @@
 		<NeutralLanguage>en</NeutralLanguage>
 
 		<!-- DON'T FORGET TO EDIT THIS -->
+		<Version>3.0.0-prerelease1</Version>
+		<InformationalVersion>3.0.0-prerelease1</InformationalVersion>
 		<PackageReleaseNotes>TODO</PackageReleaseNotes>
 
 		<Description>The plug and play SDK for the only markup language that dynamically interprets different logic paths based on an host's OS and CPU architecture.</Description>

--- a/src/RSML.Sdk/RSML.Sdk.csproj
+++ b/src/RSML.Sdk/RSML.Sdk.csproj
@@ -14,31 +14,6 @@
 		<Platforms>AnyCPU;ARM64;x64;x86</Platforms>
 	</PropertyGroup>
 
-	<PropertyGroup Label="NuGet Package Setup">
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-
-		<PackageId>OceanApocalypseStudios.RSML.Sdk</PackageId>
-		<Title>Red Sea Markup Language SDK</Title>
-		<Authors>OceanApocalypseStudios</Authors>
-		<Company>OceanApocalypseStudios</Company>
-		<NeutralLanguage>en</NeutralLanguage>
-
-		<!-- !!! DON'T FORGET TO EDIT THE VERSION AND NOTES HERE !!! -->
-		<Version>1.0.0-prerelease1</Version>
-		<PackageReleaseNotes>RSML SDK v2.0.0 is here!</PackageReleaseNotes>
-
-		<Description>The plug and play SDK for the only markup language that dynamically interprets different logic paths based on an host's OS and CPU architecture.</Description>
-		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
-		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/</PackageProjectUrl>
-		<PackageIcon>icon.png</PackageIcon>
-		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageTags>markup;language;logic;logic-path;system;host;rsml;rsea;decision;oss</PackageTags>
-		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
-
 	<PropertyGroup Label="Windows" Condition="'$(OS)' == 'Windows_NT'">
 		<DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>
 	</PropertyGroup>

--- a/src/RSML/CharExtensions.cs
+++ b/src/RSML/CharExtensions.cs
@@ -17,12 +17,12 @@ internal static class CharExtensions
 	public static bool IsAsciiEqualsIgnoreCase(this char @this, char other)
 	{
 		@this |= @this is >= 'A' and <= 'Z'
-			? (char)AsciiCaseBit
-			: (char)0;
+					 ? (char)AsciiCaseBit
+					 : (char)0;
 
 		other |= other is >= 'A' and <= 'Z'
-			? (char)AsciiCaseBit
-			: (char)0;
+					 ? (char)AsciiCaseBit
+					 : (char)0;
 
 		return @this == other;
 	}

--- a/src/RSML/CharExtensions.cs
+++ b/src/RSML/CharExtensions.cs
@@ -2,35 +2,28 @@
 using System.Runtime.CompilerServices;
 
 
-namespace OceanApocalypseStudios.RSML
+namespace OceanApocalypseStudios.RSML;
+
+internal static class CharExtensions
 {
+	public const byte AsciiCaseBit = 0x20;
 
-	internal static class CharExtensions
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool IsNewline(this char character) => character is '\r' or '\n' or '\u2028' or '\u2029';
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool IsWhiteSpace(this char character) => character != '\0' && character <= 32 && Char.IsWhiteSpace(character);
+
+	public static bool IsAsciiEqualsIgnoreCase(this char @this, char other)
 	{
+		@this |= @this is >= 'A' and <= 'Z'
+			? (char)AsciiCaseBit
+			: (char)0;
 
-		public const byte AsciiCaseBit = 0x20;
+		other |= other is >= 'A' and <= 'Z'
+			? (char)AsciiCaseBit
+			: (char)0;
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsNewline(this char character) => character is '\r' or '\n' or '\u2028' or '\u2029';
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsWhiteSpace(this char character) => character != '\0' && character <= 32 && Char.IsWhiteSpace(character);
-
-		public static bool IsAsciiEqualsIgnoreCase(this char @this, char other)
-		{
-
-			@this |= @this is >= 'A' and <= 'Z'
-				? (char)AsciiCaseBit
-				: (char)0;
-
-			other |= other is >= 'A' and <= 'Z'
-				? (char)AsciiCaseBit
-				: (char)0;
-
-			return @this == other;
-
-		}
-
+		return @this == other;
 	}
-
 }

--- a/src/RSML/CharSpanExtensions.cs
+++ b/src/RSML/CharSpanExtensions.cs
@@ -2,97 +2,78 @@
 using System.Runtime.InteropServices;
 
 
-namespace OceanApocalypseStudios.RSML
+namespace OceanApocalypseStudios.RSML;
+
+internal static class CharSpanExtensions
 {
+	public const byte AsciiCaseBit = 0x20;
 
-	internal static class CharSpanExtensions
+	internal static unsafe bool IsAsciiEqualsIgnoreCase(this ReadOnlySpan<char> chars, ReadOnlySpan<char> str)
 	{
+		if (chars.Length != str.Length)
+			return false;
 
-		public const byte AsciiCaseBit = 0x20;
-
-		internal static unsafe bool IsAsciiEqualsIgnoreCase(this ReadOnlySpan<char> chars, ReadOnlySpan<char> str)
+		fixed (char* spanPtr = &MemoryMarshal.GetReference(chars))
+		fixed (char* strPtr = &MemoryMarshal.GetReference(str))
 		{
+			char* ptrToSpan = spanPtr;
+			char* ptrToStr = strPtr;
+			int len = chars.Length;
 
-			if (chars.Length != str.Length)
-				return false;
-
-			fixed (char* spanPtr = &MemoryMarshal.GetReference(chars))
-			fixed (char* strPtr = &MemoryMarshal.GetReference(str))
+			for (int i = 0; i < len; i++)
 			{
+				char spanChar = *ptrToSpan++;
+				char strChar = *ptrToStr++;
 
-				char* ptrToSpan = spanPtr;
-				char* ptrToStr = strPtr;
-				int len = chars.Length;
-
-				for (int i = 0; i < len; i++)
-				{
-
-					char spanChar = *ptrToSpan++;
-					char strChar = *ptrToStr++;
-
-					if (!spanChar.IsAsciiEqualsIgnoreCase(strChar))
-						return false;
-
-				}
-
+				if (!spanChar.IsAsciiEqualsIgnoreCase(strChar))
+					return false;
 			}
-
-			return true;
-
 		}
 
-		public static char GetCharAt(this Span<char> span, int index)
-		{
-
-			if (index < 0)
-				index += span.Length;
-
-			if (index >= span.Length)
-				return '\0';
-
-			return span[index];
-
-		}
-
-		public static char GetCharAt(this ReadOnlySpan<char> span, int index)
-		{
-
-			if (index < 0)
-				index += span.Length;
-
-			if (index >= span.Length)
-				return '\0';
-
-			return span[index];
-
-		}
-
-		public static char GetCharAt(this string span, int index)
-		{
-
-			if (index < 0)
-				index += span.Length;
-
-			if (index >= span.Length)
-				return '\0';
-
-			return span[index];
-
-		}
-
-		public static char GetCharAt(this char[] array, int index)
-		{
-
-			if (index < 0)
-				index += array.Length;
-
-			if (index >= array.Length)
-				return '\0';
-
-			return array[index];
-
-		}
-
+		return true;
 	}
 
+	public static char GetCharAt(this Span<char> span, int index)
+	{
+		if (index < 0)
+			index += span.Length;
+
+		if (index >= span.Length)
+			return '\0';
+
+		return span[index];
+	}
+
+	public static char GetCharAt(this ReadOnlySpan<char> span, int index)
+	{
+		if (index < 0)
+			index += span.Length;
+
+		if (index >= span.Length)
+			return '\0';
+
+		return span[index];
+	}
+
+	public static char GetCharAt(this string span, int index)
+	{
+		if (index < 0)
+			index += span.Length;
+
+		if (index >= span.Length)
+			return '\0';
+
+		return span[index];
+	}
+
+	public static char GetCharAt(this char[] array, int index)
+	{
+		if (index < 0)
+			index += array.Length;
+
+		if (index >= array.Length)
+			return '\0';
+
+		return array[index];
+	}
 }

--- a/src/RSML/Common/ISupportsCache.cs
+++ b/src/RSML/Common/ISupportsCache.cs
@@ -1,29 +1,24 @@
-﻿namespace OceanApocalypseStudios.RSML.Common
+﻿namespace OceanApocalypseStudios.RSML.Common;
+
+/// <summary>
+/// Represents a service or a type that supports cached data.
+/// </summary>
+public interface ISupportsCache
 {
+	/// <summary>
+	/// Whether there's cached data.
+	/// </summary>
+	bool CacheExists { get; }
 
 	/// <summary>
-	/// Represents a service or a type that supports cached data.
+	/// Builds the cache if it doesn't exist yet.
 	/// </summary>
-	public interface ISupportsCache
-	{
+	void BuildCache();
 
-		/// <summary>
-		/// Whether there's cached data.
-		/// </summary>
-		bool CacheExists { get; }
-
-		/// <summary>
-		/// Builds the cache if it doesn't exist yet.
-		/// </summary>
-		void BuildCache();
-
-		/// <summary>
-		/// Builds the cache. If <paramref name="forceRebuild"/> is set to <c>true</c>,
-		/// the cache will be built even if it already exists.
-		/// </summary>
-		/// <param name="forceRebuild">Whether to force the cache to be built even if it exists.</param>
-		void BuildCache(bool forceRebuild);
-
-	}
-
+	/// <summary>
+	/// Builds the cache. If <paramref name="forceRebuild"/> is set to <c>true</c>,
+	/// the cache will be built even if it already exists.
+	/// </summary>
+	/// <param name="forceRebuild">Whether to force the cache to be built even if it exists.</param>
+	void BuildCache(bool forceRebuild);
 }

--- a/src/RSML/Directory.Build.props
+++ b/src/RSML/Directory.Build.props
@@ -4,12 +4,14 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
 		<PackageId>OceanApocalypseStudios.RSML</PackageId>
-		<Title>Red Sea Markup Language</Title>
+		<Title>Red Sea Markup Language (RSML)</Title>
 		<Authors>OceanApocalypseStudios</Authors>
 		<Company>OceanApocalypseStudios</Company>
 		<NeutralLanguage>en</NeutralLanguage>
 
 		<!-- DON'T FORGET TO EDIT THIS -->
+		<Version>3.0.0-prerelease1</Version>
+		<InformationalVersion>3.0.0-prerelease1</InformationalVersion>
 		<PackageReleaseNotes>TODO</PackageReleaseNotes>
 
 		<Description>The only markup language that dynamically interprets different logic paths based on an host's OS and CPU architecture.</Description>

--- a/src/RSML/Directory.Build.props
+++ b/src/RSML/Directory.Build.props
@@ -1,0 +1,26 @@
+<!-- NuGet Packaging -->
+<Project>
+	<PropertyGroup>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+
+		<PackageId>OceanApocalypseStudios.RSML</PackageId>
+		<Title>Red Sea Markup Language</Title>
+		<Authors>OceanApocalypseStudios</Authors>
+		<Company>OceanApocalypseStudios</Company>
+		<NeutralLanguage>en</NeutralLanguage>
+
+		<!-- DON'T FORGET TO EDIT THIS -->
+		<PackageReleaseNotes>TODO</PackageReleaseNotes>
+
+		<Description>The only markup language that dynamically interprets different logic paths based on an host's OS and CPU architecture.</Description>
+		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
+		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/</PackageProjectUrl>
+		<PackageIcon>icon.png</PackageIcon>
+		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>markup;language;logic;logic-path;system;host;rsml;rsea;decision;oss</PackageTags>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+</Project>

--- a/src/RSML/Directory.Build.targets
+++ b/src/RSML/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+	<!-- Windows -->
+	<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+		<DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>
+	</PropertyGroup>
+
+	<!-- Not Windows -->
+	<PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+		<DefineConstants>NOT_WINDOWS;$(DefineConstants)</DefineConstants>
+	</PropertyGroup>
+</Project>

--- a/src/RSML/Exceptions/BufferException.cs
+++ b/src/RSML/Exceptions/BufferException.cs
@@ -2,31 +2,26 @@
 using System.IO;
 
 
-namespace OceanApocalypseStudios.RSML.Exceptions
+namespace OceanApocalypseStudios.RSML.Exceptions;
+
+/// <summary>
+/// An exception that is thrown when an error occurs inside a buffer operation.
+/// </summary>
+public class BufferException : IOException
 {
+	/// <summary>
+	/// Initializes a new <see cref="BufferException"/> with no message.
+	/// </summary>
+	public BufferException() : base() { }
 
 	/// <summary>
-	/// An exception that is thrown when an error occurs inside a buffer operation.
+	/// Initializes a new <see cref="BufferException"/> with a <paramref name="message"/>.
 	/// </summary>
-	public class BufferException : IOException
-	{
+	public BufferException(string message) : base(message) { }
 
-		/// <summary>
-		/// Initializes a new <see cref="BufferException"/> with no message.
-		/// </summary>
-		public BufferException() : base() { }
-
-		/// <summary>
-		/// Initializes a new <see cref="BufferException"/> with a <paramref name="message"/>.
-		/// </summary>
-		public BufferException(string message) : base(message) { }
-
-		/// <summary>
-		/// Initializes a new <see cref="BufferException"/> with a <paramref name="message"/> and a reference
-		/// to the exception that caused this error (<paramref name="innerException"/>).
-		/// </summary>
-		public BufferException(string? message, Exception? innerException) : base(message, innerException) { }
-
-	}
-
+	/// <summary>
+	/// Initializes a new <see cref="BufferException"/> with a <paramref name="message"/> and a reference
+	/// to the exception that caused this error (<paramref name="innerException"/>).
+	/// </summary>
+	public BufferException(string? message, Exception? innerException) : base(message, innerException) { }
 }

--- a/src/RSML/Exceptions/ErrorList.cs
+++ b/src/RSML/Exceptions/ErrorList.cs
@@ -11,26 +11,26 @@ namespace OceanApocalypseStudios.RSML.Exceptions;
 /// <summary>
 /// A list of RSML toolchain errors.
 /// </summary>
-public class ErrorList() : IEnumerable<SourceError>
+public class ErrorList() : IEnumerable<IError>
 {
-	private readonly List<SourceError> errors = [];
+	private readonly List<IError> errors = [ ];
 
 	/// <summary>
 	/// Adds an error to the list of errors.
 	/// </summary>
 	/// <param name="error"></param>
-	public void Add(SourceError error) => errors.Add(error);
+	public void Add(IError error) => errors.Add(error);
 
 	/// <summary>
-	/// Adds an error to the list of errors.
+	/// Adds a <see cref="SourceError"/> to the list of errors.
 	/// </summary>
 	/// <param name="span">The span the error relates to.</param>
 	/// <param name="message">A brief description of why the error occured.</param>
 	/// <param name="severity">The error severity.</param>
-	public void Add(SourceSpan span, string message, Severity severity) => errors.Add(new(span, message, severity));
+	public void AddSourceError(SourceSpan span, string message, Severity severity) => errors.Add(new SourceError(span, message, severity));
 
 	/// <summary>
-	/// Adds an error to the list of errors.
+	/// Adds a <see cref="SourceError"/> to the list of errors.
 	/// </summary>
 	/// <param name="span">The span the error relates to.</param>
 	/// <param name="message">A pointer to an array of bytes that describe the error.</param>
@@ -38,7 +38,8 @@ public class ErrorList() : IEnumerable<SourceError>
 	/// <param name="messageEncoding">The error message encoding (this determines which encoding to use to decode <paramref name="message"/>).</param>
 	/// <param name="severity">The error severity.</param>
 	[CLSCompliant(false)]
-	public unsafe void Add(SourceSpan span, byte* message, int byteCount, Encoding? messageEncoding, Severity severity) => errors.Add(new(span, (messageEncoding ?? Encoding.Default).GetString(message, byteCount), severity));
+	public unsafe void AddSourceError(SourceSpan span, byte* message, int byteCount, Encoding? messageEncoding, Severity severity) =>
+		errors.Add(new SourceError(span, (messageEncoding ?? Encoding.Default).GetString(message, byteCount), severity));
 
 	/// <summary>
 	/// Clears the <see cref="ErrorList"/>, leaving it fully empty.
@@ -46,7 +47,7 @@ public class ErrorList() : IEnumerable<SourceError>
 	public void Clear() => errors.Clear();
 
 	/// <inheritdoc/>
-	public IEnumerator<SourceError> GetEnumerator() => errors.GetEnumerator();
+	public IEnumerator<IError> GetEnumerator() => errors.GetEnumerator();
 
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/RSML/Exceptions/ErrorList.cs
+++ b/src/RSML/Exceptions/ErrorList.cs
@@ -6,52 +6,47 @@ using System.Text;
 using OceanApocalypseStudios.RSML.Sources;
 
 
-namespace OceanApocalypseStudios.RSML.Exceptions
+namespace OceanApocalypseStudios.RSML.Exceptions;
+
+/// <summary>
+/// A list of RSML toolchain errors.
+/// </summary>
+public class ErrorList() : IEnumerable<SourceError>
 {
+	private readonly List<SourceError> errors = [];
 
 	/// <summary>
-	/// A list of RSML toolchain errors.
+	/// Adds an error to the list of errors.
 	/// </summary>
-	public class ErrorList() : IEnumerable<SourceError>
-	{
+	/// <param name="error"></param>
+	public void Add(SourceError error) => errors.Add(error);
 
-		private readonly List<SourceError> errors = [];
+	/// <summary>
+	/// Adds an error to the list of errors.
+	/// </summary>
+	/// <param name="span">The span the error relates to.</param>
+	/// <param name="message">A brief description of why the error occured.</param>
+	/// <param name="severity">The error severity.</param>
+	public void Add(SourceSpan span, string message, Severity severity) => errors.Add(new(span, message, severity));
 
-		/// <summary>
-		/// Adds an error to the list of errors.
-		/// </summary>
-		/// <param name="error"></param>
-		public void Add(SourceError error) => errors.Add(error);
+	/// <summary>
+	/// Adds an error to the list of errors.
+	/// </summary>
+	/// <param name="span">The span the error relates to.</param>
+	/// <param name="message">A pointer to an array of bytes that describe the error.</param>
+	/// <param name="byteCount">The amount of bytes in <paramref name="message"/>.</param>
+	/// <param name="messageEncoding">The error message encoding (this determines which encoding to use to decode <paramref name="message"/>).</param>
+	/// <param name="severity">The error severity.</param>
+	[CLSCompliant(false)]
+	public unsafe void Add(SourceSpan span, byte* message, int byteCount, Encoding? messageEncoding, Severity severity) => errors.Add(new(span, (messageEncoding ?? Encoding.Default).GetString(message, byteCount), severity));
 
-		/// <summary>
-		/// Adds an error to the list of errors.
-		/// </summary>
-		/// <param name="span">The span the error relates to.</param>
-		/// <param name="message">A brief description of why the error occured.</param>
-		/// <param name="severity">The error severity.</param>
-		public void Add(SourceSpan span, string message, Severity severity) => errors.Add(new(span, message, severity));
+	/// <summary>
+	/// Clears the <see cref="ErrorList"/>, leaving it fully empty.
+	/// </summary>
+	public void Clear() => errors.Clear();
 
-		/// <summary>
-		/// Adds an error to the list of errors.
-		/// </summary>
-		/// <param name="span">The span the error relates to.</param>
-		/// <param name="message">A pointer to an array of bytes that describe the error.</param>
-		/// <param name="byteCount">The amount of bytes in <paramref name="message"/>.</param>
-		/// <param name="messageEncoding">The error message encoding (this determines which encoding to use to decode <paramref name="message"/>).</param>
-		/// <param name="severity">The error severity.</param>
-		[CLSCompliant(false)]
-		public unsafe void Add(SourceSpan span, byte* message, int byteCount, Encoding? messageEncoding, Severity severity) => errors.Add(new(span, (messageEncoding ?? Encoding.Default).GetString(message, byteCount), severity));
+	/// <inheritdoc/>
+	public IEnumerator<SourceError> GetEnumerator() => errors.GetEnumerator();
 
-		/// <summary>
-		/// Clears the <see cref="ErrorList"/>, leaving it fully empty.
-		/// </summary>
-		public void Clear() => errors.Clear();
-
-		/// <inheritdoc/>
-		public IEnumerator<SourceError> GetEnumerator() => errors.GetEnumerator();
-
-		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-	}
-
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/RSML/Exceptions/IError.cs
+++ b/src/RSML/Exceptions/IError.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 
 
-namespace OceanApocalypseStudios.RSML.Exceptions
-{
+namespace OceanApocalypseStudios.RSML.Exceptions;
 
-	/// <summary>
-	/// Represents an error in the RSML toolchain.
-	/// </summary>
-	public interface IError : IEquatable<IError>, IFormattable;
-
-}
+/// <summary>
+/// Represents an error in the RSML toolchain.
+/// </summary>
+public interface IError : IEquatable<IError>, IFormattable;

--- a/src/RSML/Exceptions/Severity.cs
+++ b/src/RSML/Exceptions/Severity.cs
@@ -1,38 +1,33 @@
-﻿namespace OceanApocalypseStudios.RSML.Exceptions
+﻿namespace OceanApocalypseStudios.RSML.Exceptions;
+
+/// <summary>
+/// The severity of an error.
+/// </summary>
+public enum Severity
 {
+	/// <summary>
+	/// No severity information.
+	/// </summary>
+	None,
 
 	/// <summary>
-	/// The severity of an error.
+	/// Messages and hints.
 	/// </summary>
-	public enum Severity
-	{
+	Message,
 
-		/// <summary>
-		/// No severity information.
-		/// </summary>
-		None,
+	/// <summary>
+	/// Non-critical warnings.
+	/// </summary>
+	Warning,
 
-		/// <summary>
-		/// Messages and hints.
-		/// </summary>
-		Message,
+	/// <summary>
+	/// Non-critical errors, such as style errors.
+	/// </summary>
+	Error,
 
-		/// <summary>
-		/// Non-critical warnings.
-		/// </summary>
-		Warning,
-
-		/// <summary>
-		/// Non-critical errors, such as style errors.
-		/// </summary>
-		Error,
-
-		/// <summary>
-		/// Fatal error that should abort the executing
-		/// toolchain component.
-		/// </summary>
-		Critical
-
-	}
-
+	/// <summary>
+	/// Fatal error that should abort the executing
+	/// toolchain component.
+	/// </summary>
+	Critical
 }

--- a/src/RSML/Exceptions/SourceError.cs
+++ b/src/RSML/Exceptions/SourceError.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis; // needed despite grayed out by VS
 
 using OceanApocalypseStudios.RSML.Sources;
 

--- a/src/RSML/Exceptions/SourceError.cs
+++ b/src/RSML/Exceptions/SourceError.cs
@@ -30,7 +30,7 @@ public readonly struct SourceError(SourceSpan span, string message, Severity sev
 
 	/// <inheritdoc/>
 	public override bool Equals(object? obj) => obj is SourceError error && Equals(error);
-	
+
 	/// <inheritdoc/>
 	public bool Equals(SourceError other) => Message == other.Message && Severity == other.Severity && Span.Equals(other.Span);
 
@@ -53,6 +53,7 @@ public readonly struct SourceError(SourceSpan span, string message, Severity sev
 		{
 			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Span.GetHashCode();
 			hashCode = hashCode * InternalUtils.HashCodeMultiplier + Message.GetHashCode();
+
 			return hashCode * InternalUtils.HashCodeMultiplier + Severity.GetHashCode();
 		}
 	}
@@ -92,12 +93,12 @@ public readonly struct SourceError(SourceSpan span, string message, Severity sev
 			case "JSON":
 				return
 					$$"""
-					{
-						"span": {{span.ToString("JSON", null)}},
-						"message": "{{message}}",
-						"severity": "{{severity}}"
-					}
-					""";
+					  {
+					  	"span": {{span.ToString("JSON", null)}},
+					  	"message": "{{message}}",
+					  	"severity": "{{severity}}"
+					  }
+					  """;
 
 			default:
 				return ToString();

--- a/src/RSML/Exceptions/SourceError.cs
+++ b/src/RSML/Exceptions/SourceError.cs
@@ -3,118 +3,104 @@
 using OceanApocalypseStudios.RSML.Sources;
 
 
-namespace OceanApocalypseStudios.RSML.Exceptions
+namespace OceanApocalypseStudios.RSML.Exceptions;
+
+/// <summary>
+/// An error that has happened in the RSML toolchain and comes from a source.
+/// </summary>
+/// <param name="span">The span the error relates to.</param>
+/// <param name="message">A brief error message detailing why it has happened.</param>
+/// <param name="severity">The error's severity.</param>
+public readonly struct SourceError(SourceSpan span, string message, Severity severity) : IError, IEquatable<SourceError>
 {
+	/// <summary>
+	/// The span the error relates to.
+	/// </summary>
+	public SourceSpan Span => span;
 
 	/// <summary>
-	/// An error that has happened in the RSML toolchain and comes from a source.
+	/// A brief error message detailing why it has happened.
 	/// </summary>
-	/// <param name="span">The span the error relates to.</param>
-	/// <param name="message">A brief error message detailing why it has happened.</param>
-	/// <param name="severity">The error's severity.</param>
-	public readonly struct SourceError(SourceSpan span, string message, Severity severity) : IError, IEquatable<SourceError>
+	public string Message => message;
+
+	/// <summary>
+	/// The error's severity.
+	/// </summary>
+	public Severity Severity => severity;
+
+	/// <inheritdoc/>
+	public override bool Equals(object? obj) => obj is SourceError error && Equals(error);
+	
+	/// <inheritdoc/>
+	public bool Equals(SourceError other) => Message == other.Message && Severity == other.Severity && Span.Equals(other.Span);
+
+	/// <summary>
+	/// Checks if two <see cref="SourceError"/>s are equal to each other.
+	/// </summary>
+	/// <returns>True if equals.</returns>
+	public static bool operator ==(SourceError left, SourceError right) => left.Equals(right);
+
+	/// <summary>
+	/// Checks if two <see cref="SourceError"/>s are different from each other.
+	/// </summary>
+	/// <returns>True if different.</returns>
+	public static bool operator !=(SourceError left, SourceError right) => !left.Equals(right);
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
 	{
-
-		/// <summary>
-		/// The span the error relates to.
-		/// </summary>
-		public SourceSpan Span => span;
-
-		/// <summary>
-		/// A brief error message detailing why it has happened.
-		/// </summary>
-		public string Message => message;
-
-		/// <summary>
-		/// The error's severity.
-		/// </summary>
-		public Severity Severity => severity;
-
-		/// <inheritdoc/>
-		public override bool Equals(object? obj) => obj is SourceError error && Equals(error);
-		
-		/// <inheritdoc/>
-		public bool Equals(SourceError other) => Message == other.Message && Severity == other.Severity && Span.Equals(other.Span);
-
-		/// <summary>
-		/// Checks if two <see cref="SourceError"/>s are equal to each other.
-		/// </summary>
-		/// <returns>True if equals.</returns>
-		public static bool operator ==(SourceError left, SourceError right) => left.Equals(right);
-
-		/// <summary>
-		/// Checks if two <see cref="SourceError"/>s are different from each other.
-		/// </summary>
-		/// <returns>True if different.</returns>
-		public static bool operator !=(SourceError left, SourceError right) => !left.Equals(right);
-
-		/// <inheritdoc/>
-		public override int GetHashCode()
+		unchecked
 		{
-
-			unchecked
-			{
-
-				int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Span.GetHashCode();
-				hashCode = hashCode * InternalUtils.HashCodeMultiplier + Message.GetHashCode();
-				return hashCode * InternalUtils.HashCodeMultiplier + Severity.GetHashCode();
-
-			}
-
+			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Span.GetHashCode();
+			hashCode = hashCode * InternalUtils.HashCodeMultiplier + Message.GetHashCode();
+			return hashCode * InternalUtils.HashCodeMultiplier + Severity.GetHashCode();
 		}
-
-		/// <inheritdoc/>
-		public bool Equals(IError? other) => other is SourceError error && Equals(error);
-
-		/// <summary>
-		/// Returns a generic string representation of the current instance.
-		/// </summary>
-		/// <returns>The string representation.</returns>
-		public override string ToString() => $"SourceError(Span={span}, Message={message}, Severity={severity})";
-
-		/// <summary>
-		/// Given a format, tries to return a string that uses said format as a basis for the representation.
-		/// If it fails, it defaults to <see cref="ToString()"/>.
-		/// </summary>
-		/// <param name="format">The format. Available formats are: CTOR (constructor-like string), LOG (output-ready format) and JSON (struct as JSON).</param>
-		/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
-		/// <returns>The string representation.</returns>
-		public string ToString(string? format, IFormatProvider? formatProvider)
-		{
-
-			switch (format)
-			{
-
-				case "CTOR":
-				case "I":
-				case "INIT":
-				case "NET":
-					return $"new SourceError({Span.ToString("ctor", null)}, \"{Message}\", {Severity})";
-
-				case "LOG":
-					if (span.IsSingleLine)
-						return $"ERROR: {message} (line {span.Start.Line + 1}, column range {span.Start.Column + 1}..{span.End.Column + 1})";
-
-					return $"ERROR: {message} (line range {span.Start.Line + 1}..{span.End.Line + 1}, column range {span.Start.Column + 1}..{span.End.Column + 1})";
-
-
-				case "JSON":
-					return
-						$$"""
-						{
-							"span": {{span.ToString("JSON", null)}},
-							"message": "{{message}}",
-							"severity": "{{severity}}"
-						}
-						""";
-
-				default:
-					return ToString();
-
-			}
-
-		}
-
 	}
 
+	/// <inheritdoc/>
+	public bool Equals(IError? other) => other is SourceError error && Equals(error);
+
+	/// <summary>
+	/// Returns a generic string representation of the current instance.
+	/// </summary>
+	/// <returns>The string representation.</returns>
+	public override string ToString() => $"SourceError(Span={span}, Message={message}, Severity={severity})";
+
+	/// <summary>
+	/// Given a format, tries to return a string that uses said format as a basis for the representation.
+	/// If it fails, it defaults to <see cref="ToString()"/>.
+	/// </summary>
+	/// <param name="format">The format. Available formats are: CTOR (constructor-like string), LOG (output-ready format) and JSON (struct as JSON).</param>
+	/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
+	/// <returns>The string representation.</returns>
+	public string ToString(string? format, IFormatProvider? formatProvider)
+	{
+		switch (format)
+		{
+			case "CTOR":
+			case "I":
+			case "INIT":
+			case "NET":
+				return $"new SourceError({Span.ToString("ctor", null)}, \"{Message}\", {Severity})";
+
+			case "LOG":
+				if (span.IsSingleLine)
+					return $"ERROR: {message} (line {span.Start.Line + 1}, column range {span.Start.Column + 1}..{span.End.Column + 1})";
+
+				return $"ERROR: {message} (line range {span.Start.Line + 1}..{span.End.Line + 1}, column range {span.Start.Column + 1}..{span.End.Column + 1})";
+
+			case "JSON":
+				return
+					$$"""
+					{
+						"span": {{span.ToString("JSON", null)}},
+						"message": "{{message}}",
+						"severity": "{{severity}}"
+					}
+					""";
+
+			default:
+				return ToString();
+		}
+	}
 }

--- a/src/RSML/Exceptions/SourceError.cs
+++ b/src/RSML/Exceptions/SourceError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis; // needed despite grayed out by VS
 
 using OceanApocalypseStudios.RSML.Sources;
 
@@ -29,7 +30,12 @@ public readonly struct SourceError(SourceSpan span, string message, Severity sev
 	public Severity Severity => severity;
 
 	/// <inheritdoc/>
-	public override bool Equals(object? obj) => obj is SourceError error && Equals(error);
+#if NET10_0_OR_GREATER
+	public override bool Equals([NotNullWhen(true)] object? obj) =>
+#elif NETSTANDARD2_0
+	public override bool Equals(object obj) =>
+#endif
+		obj is SourceError error && Equals(error);
 
 	/// <inheritdoc/>
 	public bool Equals(SourceError other) => Message == other.Message && Severity == other.Severity && Span.Equals(other.Span);

--- a/src/RSML/GlobalSuppressions.cs
+++ b/src/RSML/GlobalSuppressions.cs
@@ -2,16 +2,13 @@
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
-
-using SM = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute; // SUPPRESS MESSAGE
 using C = OceanApocalypseStudios.RSML.InternalUtils;
 
-
 // Code style.
-[assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.Char[],System.Int32)~System.Char")]
-[assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.ReadOnlySpan{System.Char},System.Int32)~System.Char")]
-[assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.Span{System.Char},System.Int32)~System.Char")]
-[assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.String,System.Int32)~System.Char")]
+[assembly: SuppressMessage("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.Char[],System.Int32)~System.Char")]
+[assembly: SuppressMessage("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.ReadOnlySpan{System.Char},System.Int32)~System.Char")]
+[assembly: SuppressMessage("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.Span{System.Char},System.Int32)~System.Char")]
+[assembly: SuppressMessage("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.String,System.Int32)~System.Char")]
 
 // Issues caused by targetting more than one framework.
 // [assembly: SM("Style", C.Ide0056, Justification = ".NET Standard 2.0 does not support the use of Index.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.Sources.Buffers.StringBuffer.GetLineSeparatorBefore(System.Int32, System.Int32)~System.Int32")]

--- a/src/RSML/GlobalSuppressions.cs
+++ b/src/RSML/GlobalSuppressions.cs
@@ -12,7 +12,6 @@ using C = OceanApocalypseStudios.RSML.InternalUtils;
 [assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.ReadOnlySpan{System.Char},System.Int32)~System.Char")]
 [assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.Span{System.Char},System.Int32)~System.Char")]
 [assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.String,System.Int32)~System.Char")]
-[assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.Sources.Buffers.ReadOnlyStringBuffer.GetLineSeparatorBefore(System.Int32,System.Int32@)~System.Int32")]
 
 // Issues caused by targetting more than one framework.
 // [assembly: SM("Style", C.Ide0056, Justification = ".NET Standard 2.0 does not support the use of Index.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.Sources.Buffers.StringBuffer.GetLineSeparatorBefore(System.Int32, System.Int32)~System.Int32")]

--- a/src/RSML/GlobalSuppressions.cs
+++ b/src/RSML/GlobalSuppressions.cs
@@ -6,6 +6,7 @@
 using SM = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute; // SUPPRESS MESSAGE
 using C = OceanApocalypseStudios.RSML.InternalUtils;
 
+
 // Code style.
 [assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.Char[],System.Int32)~System.Char")]
 [assembly: SM("Style", C.Ide0046, Justification = "The conditional expression in this case hurts readability.", Scope = "member", Target = "~M:OceanApocalypseStudios.RSML.CharSpanExtensions.GetCharAt(System.ReadOnlySpan{System.Char},System.Int32)~System.Char")]

--- a/src/RSML/GlobalUsings.cs
+++ b/src/RSML/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using System.Diagnostics.CodeAnalysis; // needed for .NET 10 and suppressions

--- a/src/RSML/InternalUtils.cs
+++ b/src/RSML/InternalUtils.cs
@@ -1,15 +1,10 @@
-﻿namespace OceanApocalypseStudios.RSML
+﻿namespace OceanApocalypseStudios.RSML;
+
+internal static class InternalUtils
 {
+	public const string Ide0046 = "IDE0046:Convert to conditional expression";
+	public const string Ide0056 = "IDE0056:Use index operator";
 
-	internal static class InternalUtils
-	{
-
-		public const string Ide0046 = "IDE0046:Convert to conditional expression";
-		public const string Ide0056 = "IDE0056:Use index operator";
-
-		public const int HashCodeSeed = unchecked(-333_794_335);
-		public const int HashCodeMultiplier = unchecked(-1_521_134_295);
-
-	}
-
+	public const int HashCodeSeed = unchecked(-333_794_335);
+	public const int HashCodeMultiplier = unchecked(-1_521_134_295);
 }

--- a/src/RSML/Language/Implementations/Lexer.cs
+++ b/src/RSML/Language/Implementations/Lexer.cs
@@ -1,15 +1,11 @@
 ﻿using OceanApocalypseStudios.RSML.Language.Lexer;
 
-namespace OceanApocalypseStudios.RSML.Language.Implementations
+
+namespace OceanApocalypseStudios.RSML.Language.Implementations;
+
+internal class Lexer : ILexer
 {
-
-	internal class Lexer : ILexer
-	{
-
-		// todo: implement ILexer here
-		// thank you thank you thank you
-		// ok ill stop with the fuckass 'thank you' now
-
-	}
-
+	// todo: implement ILexer here
+	// thank you thank you thank you
+	// ok ill stop with the fuckass 'thank you' now
 }

--- a/src/RSML/Language/Lexer/ILexer.cs
+++ b/src/RSML/Language/Lexer/ILexer.cs
@@ -1,14 +1,9 @@
-﻿namespace OceanApocalypseStudios.RSML.Language.Lexer
+﻿namespace OceanApocalypseStudios.RSML.Language.Lexer;
+
+public interface ILexer
 {
+	// todo: add necessary content to ILexer
+	// thank you thank you thank you
 
-	public interface ILexer
-	{
-
-		// todo: add necessary content to ILexer
-		// thank you thank you thank you
-
-		// xxx: we might need a Line ref struct still deciding
-
-	}
-
+	// xxx: we might need a Line ref struct still deciding
 }

--- a/src/RSML/Language/Syntax/SyntaxToken.cs
+++ b/src/RSML/Language/Syntax/SyntaxToken.cs
@@ -1,12 +1,7 @@
-﻿namespace OceanApocalypseStudios.RSML.Language.Syntax
+﻿namespace OceanApocalypseStudios.RSML.Language.Syntax;
+
+public ref struct SyntaxToken
 {
-
-	public ref struct SyntaxToken
-	{
-
-		// todo: add necessary content to SyntaxToken
-		// thank you thank you thank you
-
-	}
-
+	// todo: add necessary content to SyntaxToken
+	// thank you thank you thank you
 }

--- a/src/RSML/Language/Syntax/TokenKind.cs
+++ b/src/RSML/Language/Syntax/TokenKind.cs
@@ -1,12 +1,7 @@
-﻿namespace OceanApocalypseStudios.RSML.Language.Syntax
+﻿namespace OceanApocalypseStudios.RSML.Language.Syntax;
+
+public enum TokenKind
 {
-
-	public enum TokenKind
-	{
-
-		// todo: add token kinds here
-		// thank you thank you thank you
-
-	}
-
+	// todo: add token kinds here
+	// thank you thank you thank you
 }

--- a/src/RSML/RSML.csproj
+++ b/src/RSML/RSML.csproj
@@ -14,39 +14,6 @@
 		<Platforms>AnyCPU;ARM64;x64;x86</Platforms>
 	</PropertyGroup>
 
-	<PropertyGroup Label="NuGet Package Setup">
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-
-		<PackageId>OceanApocalypseStudios.RSML</PackageId>
-		<Title>Red Sea Markup Language</Title>
-		<Authors>OceanApocalypseStudios</Authors>
-		<Company>OceanApocalypseStudios</Company>
-		<NeutralLanguage>en</NeutralLanguage>
-
-		<!-- !!! DON'T FORGET TO EDIT THE VERSION AND NOTES HERE !!! -->
-		<Version>3.0.0-prerelease1</Version>
-		<PackageReleaseNotes>RSML v2.0.0 is here!</PackageReleaseNotes>
-
-		<Description>The only markup language that dynamically interprets different logic paths based on an host's OS and CPU architecture.</Description>
-		<Copyright>Copyright (c) 2025 OceanApocalypseStudios</Copyright>
-		<PackageProjectUrl>https://oceanapocalypsestudios.org/rsml-docs/</PackageProjectUrl>
-		<PackageIcon>icon.png</PackageIcon>
-		<RepositoryUrl>https://github.com/OceanApocalypseStudios/RedSeaMarkupLanguage/</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageTags>markup;language;logic;logic-path;system;host;rsml;rsea;decision;oss</PackageTags>
-		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
-
-	<PropertyGroup Label="Windows" Condition="'$(OS)' == 'Windows_NT'">
-		<DefineConstants>WINDOWS;$(DefineConstants)</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Label="Not Windows" Condition="'$(OS)' != 'Windows_NT'">
-		<DefineConstants>NOT_WINDOWS;$(DefineConstants)</DefineConstants>
-	</PropertyGroup>
-
 	<PropertyGroup Label="Debug Build" Condition="'$(Configuration)' == 'Debug'">
 		<DebugType>full</DebugType>
 		<CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
@@ -72,14 +39,6 @@
 
 	<ItemGroup Label="Memory Extensions" Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="System.Memory" Version="4.6.3" />
-	</ItemGroup>
-
-	<ItemGroup Label=".NET 10" Condition="'$(TargetFramework)' == 'net10.0'">
-		<Compile Remove="**\*.NetStd2.cs" />
-	</ItemGroup>
-
-	<ItemGroup Label=".NET Standard 2.0" Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<Compile Remove="**\*.Net10.cs" />
 	</ItemGroup>
 
 </Project>

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -75,6 +75,12 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// Determines the 0-based line number of the line that contains the item located at <paramref name="index"/>.
 	/// </summary>
 	/// <param name="index">The index whose parent line's number is to be returned.</param>
+	/// <remarks>
+	/// > [!NOTE]
+	/// > This method follows the convention where the index can be equal to the buffer's length,
+	/// > which means to consider the end of the buffer.
+	/// > When index is set to EOF, for this method, it returns <see cref="LineCount"/>.
+	/// </remarks>
 	/// <returns>The 0-based number of the line that contains item located at <paramref name="index"/>.</returns>
 	int GetLineNumberAt(int index);
 

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -16,8 +16,11 @@ namespace OceanApocalypseStudios.RSML.Sources.Buffers;
 public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TItem>?>
 {
 	/// <summary>
-	/// The amount of lines in the buffer.
+	/// The total amount of lines in the buffer.
 	/// </summary>
+	/// <remarks>
+	/// Keep in mind lines might be empty.
+	/// </remarks>
 	int LineCount { get; }
 
 	/// <summary>
@@ -35,7 +38,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// <param name="isCrLf">
 	/// Whether the line separator at which the method stopped is the CR in a CRLF sequence. If true, the next item in the buffer is LF.
 	/// </param>
-	/// <returns>The index of the next line separator, relative to an <paramref name="index"/> or -1 if out of bounds.</returns>
+	/// <returns>The index of the next line separator, relative to an <paramref name="index"/>.</returns>
 	int CountUntilLineSeparator(int index, out bool isCrLf);
 
 	/// <summary>
@@ -43,7 +46,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// Line separators are included in the whitespace category.
 	/// </summary>
 	/// <param name="index">The index at which to start counting.</param>
-	/// <returns>The index of the next non-whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
+	/// <returns>The index of the next non-whitespace item, relative to a <paramref name="index"/>.</returns>
 	int CountUntilNotWhitespace(int index);
 
 	/// <summary>
@@ -51,7 +54,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// Line separators are included in the whitespace category.
 	/// </summary>
 	/// <param name="index">The index at which to start counting.</param>
-	/// <returns>The index of the next whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
+	/// <returns>The index of the next whitespace item, relative to a <paramref name="index"/>.</returns>
 	int CountUntilWhitespace(int index);
 
 	/// <summary>
@@ -68,19 +71,13 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// <paramref name="predicate"/> as an offset that when added to the index of the position
 	/// equal the actual index.
 	/// </param>
-	/// <returns>The amount of items counted or -1 if out of bounds.</returns>
+	/// <returns>The amount of items counted.</returns>
 	int CountWhile(Func<int, TItem, bool> predicate, int index);
 
 	/// <summary>
 	/// Determines the 0-based line number of the line that contains the item located at <paramref name="index"/>.
 	/// </summary>
 	/// <param name="index">The index whose parent line's number is to be returned.</param>
-	/// <remarks>
-	/// > [!NOTE]
-	/// > This method follows the convention where the index can be equal to the buffer's length,
-	/// > which means to consider the end of the buffer.
-	/// > When index is set to EOF, for this method, it returns <see cref="LineCount"/>.
-	/// </remarks>
 	/// <returns>The 0-based number of the line that contains item located at <paramref name="index"/>.</returns>
 	int GetLineNumberAt(int index);
 

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -21,12 +21,11 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	int LineCount { get; }
 
 	/// <summary>
-	/// Counts the amount of items until the next whitespace item in the buffer, relative to a given <paramref name="index"/>.
-	/// Line separators are included in the whitespace category.
+	/// Gets a single item out of the buffer.
 	/// </summary>
-	/// <param name="index">The index at which to start counting.</param>
-	/// <returns>The index of the next whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
-	int CountUntilWhitespace(int index);
+	/// <param name="index">The index of the item to retrieve.</param>
+	/// <returns>The item.</returns>
+	TItem this[int index] { get; }
 
 	/// <summary>
 	/// Counts the amount of items until the next line separator in the buffer, relative to a given <paramref name="index"/>.
@@ -38,6 +37,22 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// </param>
 	/// <returns>The index of the next line separator, relative to an <paramref name="index"/> or -1 if out of bounds.</returns>
 	int CountUntilLineSeparator(int index, out bool isCrLf);
+
+	/// <summary>
+	/// Counts the amount of items until the next non-whitespace item in the buffer, relative to a given <paramref name="index"/>.
+	/// Line separators are included in the whitespace category.
+	/// </summary>
+	/// <param name="index">The index at which to start counting.</param>
+	/// <returns>The index of the next non-whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
+	int CountUntilNotWhitespace(int index);
+
+	/// <summary>
+	/// Counts the amount of items until the next whitespace item in the buffer, relative to a given <paramref name="index"/>.
+	/// Line separators are included in the whitespace category.
+	/// </summary>
+	/// <param name="index">The index at which to start counting.</param>
+	/// <returns>The index of the next whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
+	int CountUntilWhitespace(int index);
 
 	/// <summary>
 	/// Counts the amount of items, starting from a given <paramref name="index"/>,
@@ -57,12 +72,60 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	int CountWhile(Func<int, TItem, bool> predicate, int index);
 
 	/// <summary>
+	/// Determines the 0-based line number of the line that contains the item located at <paramref name="index"/>.
+	/// </summary>
+	/// <param name="index">The index whose parent line's number is to be returned.</param>
+	/// <returns>The 0-based number of the line that contains item located at <paramref name="index"/>.</returns>
+	int GetLineNumberAt(int index);
+
+	/// <summary>
+	/// Slices a region of the buffer.
+	/// </summary>
+	/// <param name="start">The index of the first item in the slice.</param>
+	/// <param name="length">The amount of items to slice starting at <paramref name="start"/>.</param>
+	/// <returns>A slice, as an array of items.</returns>
+	TItem[] Slice(int start, int length);
+
+	/// <summary>
+	/// Slices a region of the buffer into a performant span.
+	/// </summary>
+	/// <param name="start">The index of the first item in the slice.</param>
+	/// <param name="slice">The span serving as the destination for the slice.</param>
+	void Slice(int start, Span<TItem> slice);
+
+	/// <summary>
+	/// Slices a region of the buffer into a performant span.
+	/// </summary>
+	/// <param name="sourceSpan">The span indicating what the slice is.</param>
+	/// <param name="slice">The span serving as the destination for the slice.</param>
+	void Slice(SourceSpan sourceSpan, Span<TItem> slice);
+
+	/// <summary>
 	/// Tries to read the next item in the buffer, relative to an <paramref name="index"/>.
 	/// </summary>
 	/// <param name="index">The index of the character.</param>
 	/// <param name="item">The item.</param>
 	/// <returns>False if the buffer is out of bounds or an exception occured.</returns>
 	bool TryGetChar(int index, out TItem item);
+
+	/// <summary>
+	/// Given a 0-based line number, assigns the exact line to a result buffer (<paramref name="destination"/>).
+	/// </summary>
+	/// <param name="lineNumber">The 0-based line number.</param>
+	/// <param name="destination">The destination buffer for the line.</param>
+	/// <param name="itemCount">The amount of items returned.</param>
+	/// <returns>True if successful.</returns>
+	bool TryGetLine(int lineNumber, Span<TItem> destination, out int itemCount);
+
+	/// <summary>
+	/// Tries to read the line that contains the item at <paramref name="index"/>.
+	/// No end of line characters are added.
+	/// </summary>
+	/// <param name="index">The index at which to determine what the current line is.</param>
+	/// <param name="line">The destination span that will contain the line.</param>
+	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
+	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
+	bool TryGetLineAt(int index, Span<TItem> line, out int itemCount);
 
 	/// <summary>
 	/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
@@ -91,14 +154,32 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	bool TryGetNextLineFrom(int index, Span<TItem> line, bool skipEmptyLines, out int itemCount);
 
 	/// <summary>
-	/// Tries to read the line that contains the item at <paramref name="index"/>.
-	/// No end of line characters are added.
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of items verified by
+	/// <paramref name="itemKindPredicate"/> (if the starting index is verified by <paramref name="itemKindPredicate"/>)
+	/// or a span of content not verified by <paramref name="itemKindPredicate"/> (if
+	/// the starting index does not point to anything verified by <paramref name="itemKindPredicate"/>).
 	/// </summary>
-	/// <param name="index">The index at which to determine what the current line is.</param>
-	/// <param name="line">The destination span that will contain the line.</param>
-	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
-	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-	bool TryGetLineAt(int index, Span<TItem> line, out int itemCount);
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="itemKindPredicate">
+	/// A predicate that verifies if the first item in the selected range serves as the delimiter
+	/// (the predicate returns <c>true</c> if so). For example, if the predicate verifies <c>,</c>, then 
+	/// the current word if the buffer is <c>My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
+	/// is <c>My awesome buffer</c>. If the predicate verifies <c>;</c>, then the current word
+	/// if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
+	/// </param>
+	/// <param name="destination">The span which will be the destination for the read content.</param>
+	/// <param name="isItemKind">
+	/// True if the span is fully comprised of the item kind verified by <paramref name="itemKindPredicate"/>.
+	/// If False, no items verified by <paramref name="itemKindPredicate"/> is present.
+	/// </param>
+	/// <param name="itemCount">The amount of characters that were written to <paramref name="destination"/>.</param>
+	/// <remarks>
+	/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
+	/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
+	/// will be set to something greater than <c>0</c>.
+	/// </remarks>
+	/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
+	bool TryGetWord(int index, Func<int, TItem, bool> itemKindPredicate, Span<TItem> destination, out bool isItemKind, out int itemCount);
 
 	/// <summary>
 	/// Tries to read the word at index <paramref name="index"/>, which can be a span of whitespace (if the starting index points to whitespace)
@@ -141,78 +222,4 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// </remarks>
 	/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
 	bool TryGetWord(int index, TItem itemKind, Span<TItem> destination, out bool isItemKind, out int itemCount);
-
-	/// <summary>
-	/// Tries to read the word at index <paramref name="index"/>, which can be a span of items verified by
-	/// <paramref name="itemKindPredicate"/> (if the starting index is verified by <paramref name="itemKindPredicate"/>)
-	/// or a span of content not verified by <paramref name="itemKindPredicate"/> (if
-	/// the starting index does not point to anything verified by <paramref name="itemKindPredicate"/>).
-	/// </summary>
-	/// <param name="index">The index at which the word starts.</param>
-	/// <param name="itemKindPredicate">
-	/// A predicate that verifies if the first item in the selected range serves as the delimiter
-	/// (the predicate returns <c>true</c> if so). For example, if the predicate verifies <c>,</c>, then 
-	/// the current word if the buffer is <c>My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
-	/// is <c>My awesome buffer</c>. If the predicate verifies <c>;</c>, then the current word
-	/// if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
-	/// </param>
-	/// <param name="destination">The span which will be the destination for the read content.</param>
-	/// <param name="isItemKind">
-	/// True if the span is fully comprised of the item kind verified by <paramref name="itemKindPredicate"/>.
-	/// If False, no items verified by <paramref name="itemKindPredicate"/> is present.
-	/// </param>
-	/// <param name="itemCount">The amount of characters that were written to <paramref name="destination"/>.</param>
-	/// <remarks>
-	/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
-	/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
-	/// will be set to something greater than <c>0</c>.
-	/// </remarks>
-	/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
-	bool TryGetWord(int index, Func<int, TItem, bool> itemKindPredicate, Span<TItem> destination, out bool isItemKind, out int itemCount);
-
-	/// <summary>
-	/// Given a 0-based line number, assigns the exact line to a result buffer (<paramref name="destination"/>).
-	/// </summary>
-	/// <param name="lineNumber">The 0-based line number.</param>
-	/// <param name="destination">The destination buffer for the line.</param>
-	/// <param name="itemCount">The amount of items returned.</param>
-	/// <returns>True if successful.</returns>
-	bool TryGetLine(int lineNumber, Span<TItem> destination, out int itemCount);
-
-	/// <summary>
-	/// Counts the amount of items until the next non-whitespace item in the buffer, relative to a given <paramref name="index"/>.
-	/// Line separators are included in the whitespace category.
-	/// </summary>
-	/// <param name="index">The index at which to start counting.</param>
-	/// <returns>The index of the next non-whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
-	int CountUntilNotWhitespace(int index);
-
-	/// <summary>
-	/// Slices a region of the buffer.
-	/// </summary>
-	/// <param name="start">The index of the first item in the slice.</param>
-	/// <param name="length">The amount of items to slice starting at <paramref name="start"/>.</param>
-	/// <returns>A slice, as an array of items.</returns>
-	TItem[] Slice(int start, int length);
-
-	/// <summary>
-	/// Slices a region of the buffer into a performant span.
-	/// </summary>
-	/// <param name="start">The index of the first item in the slice.</param>
-	/// <param name="slice">The span serving as the destination for the slice.</param>
-	void Slice(int start, Span<TItem> slice);
-
-	/// <summary>
-	/// Slices a region of the buffer into a performant span.
-	/// </summary>
-	/// <param name="sourceSpan">The span indicating what the slice is.</param>
-	/// <param name="slice">The span serving as the destination for the slice.</param>
-	void Slice(SourceSpan sourceSpan, Span<TItem> slice);
-
-	/// <summary>
-	/// Gets a single item out of the buffer.
-	/// </summary>
-	/// <param name="index">The index of the item to retrieve.</param>
-	/// <returns>The item.</returns>
-	TItem this[int index] { get; }
 }

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -128,7 +128,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// <param name="line">The destination span that will contain the line.</param>
 	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
 	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-	bool TryGetLineAt(int index, Span<TItem> line, out int itemCount);
+	bool TryGetLineFromIndex(int index, Span<TItem> line, out int itemCount);
 
 	/// <summary>
 	/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
@@ -140,7 +140,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// <param name="line">The destination span that will contain the line.</param>
 	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
 	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-	bool TryGetNextLineFrom(int index, Span<TItem> line, out int itemCount);
+	bool TryGetLineAfterIndex(int index, Span<TItem> line, out int itemCount);
 
 	/// <summary>
 	/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
@@ -154,7 +154,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// <param name="skipEmptyLines">Whether to skip lines that are composed only of line separators.</param>
 	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
 	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-	bool TryGetNextLineFrom(int index, Span<TItem> line, bool skipEmptyLines, out int itemCount);
+	bool TryGetLineAfterIndex(int index, Span<TItem> line, bool skipEmptyLines, out int itemCount);
 
 	/// <summary>
 	/// Tries to read the word at index <paramref name="index"/>, which can be a span of items verified by

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -79,7 +79,7 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	/// </summary>
 	/// <param name="index">The index whose parent line's number is to be returned.</param>
 	/// <returns>The 0-based number of the line that contains item located at <paramref name="index"/>.</returns>
-	int GetLineNumberAt(int index);
+	int GetLineNumberForIndex(int index);
 
 	/// <summary>
 	/// Slices a region of the buffer.

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -13,7 +13,7 @@ namespace OceanApocalypseStudios.RSML.Sources.Buffers;
 /// Represents a buffer.
 /// </summary>
 /// <typeparam name="TItem">The datatype of the values returned by the buffer methods</typeparam>
-public interface IReadOnlyBuffer<TItem> : ISource
+public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TItem>?>
 {
 	/// <summary>
 	/// The amount of lines in the buffer.

--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -1,223 +1,218 @@
 ﻿using System;
 
 
-namespace OceanApocalypseStudios.RSML.Sources.Buffers
+namespace OceanApocalypseStudios.RSML.Sources.Buffers;
+
+// TODO: cleanup this interface, change some signatures
+// xxx: this interface has to be IMPECABLE!
+// i fucking have no idea how to spell impecable
+
+// see #50 and #53 and #54
+
+/// <summary>
+/// Represents a buffer.
+/// </summary>
+/// <typeparam name="TItem">The datatype of the values returned by the buffer methods</typeparam>
+public interface IReadOnlyBuffer<TItem> : ISource
 {
-
-	// TODO: cleanup this interface, change some signatures
-	// xxx: this interface has to be IMPECABLE!
-	// i fucking have no idea how to spell impecable
-
-	// see #50 and #53 and #54
+	/// <summary>
+	/// The amount of lines in the buffer.
+	/// </summary>
+	int LineCount { get; }
 
 	/// <summary>
-	/// Represents a buffer.
+	/// Counts the amount of items until the next whitespace item in the buffer, relative to a given <paramref name="index"/>.
+	/// Line separators are included in the whitespace category.
 	/// </summary>
-	/// <typeparam name="TItem">The datatype of the values returned by the buffer methods</typeparam>
-	public interface IReadOnlyBuffer<TItem> : ISource
-	{
+	/// <param name="index">The index at which to start counting.</param>
+	/// <returns>The index of the next whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
+	int CountUntilWhitespace(int index);
 
-		/// <summary>
-		/// The amount of lines in the buffer.
-		/// </summary>
-		int LineCount { get; }
+	/// <summary>
+	/// Counts the amount of items until the next line separator in the buffer, relative to a given <paramref name="index"/>.
+	/// Only line separators count - regular whitespace do not. CRLF counts as a single line separator, to avoid double counting.
+	/// </summary>
+	/// <param name="index">The index at which to start counting.</param>
+	/// <param name="isCrLf">
+	/// Whether the line separator at which the method stopped is the CR in a CRLF sequence. If true, the next item in the buffer is LF.
+	/// </param>
+	/// <returns>The index of the next line separator, relative to an <paramref name="index"/> or -1 if out of bounds.</returns>
+	int CountUntilLineSeparator(int index, out bool isCrLf);
 
-		/// <summary>
-		/// Counts the amount of items until the next whitespace item in the buffer, relative to a given <paramref name="index"/>.
-		/// Line separators are included in the whitespace category.
-		/// </summary>
-		/// <param name="index">The index at which to start counting.</param>
-		/// <returns>The index of the next whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
-		int CountUntilWhitespace(int index);
+	/// <summary>
+	/// Counts the amount of items, starting from a given <paramref name="index"/>,
+	/// while a <paramref name="predicate"/> returns <c>true</c>.
+	/// </summary>
+	/// <param name="predicate">
+	/// A function that takes the current index (relative to <paramref name="index"/>),
+	/// which is incremented every item, and the item associated with it. Execution stops when
+	/// the predicate returns <c>false</c> or the index is out of bounds.
+	/// </param>
+	/// <param name="index">
+	/// The index at which to start counting; all indexes will also be given to the
+	/// <paramref name="predicate"/> as an offset that when added to the index of the position
+	/// equal the actual index.
+	/// </param>
+	/// <returns>The amount of items counted or -1 if out of bounds.</returns>
+	int CountWhile(Func<int, TItem, bool> predicate, int index);
 
-		/// <summary>
-		/// Counts the amount of items until the next line separator in the buffer, relative to a given <paramref name="index"/>.
-		/// Only line separators count - regular whitespace do not. CRLF counts as a single line separator, to avoid double counting.
-		/// </summary>
-		/// <param name="index">The index at which to start counting.</param>
-		/// <param name="isCrLf">
-		/// Whether the line separator at which the method stopped is the CR in a CRLF sequence. If true, the next item in the buffer is LF.
-		/// </param>
-		/// <returns>The index of the next line separator, relative to an <paramref name="index"/> or -1 if out of bounds.</returns>
-		int CountUntilLineSeparator(int index, out bool isCrLf);
+	/// <summary>
+	/// Tries to read the next item in the buffer, relative to an <paramref name="index"/>.
+	/// </summary>
+	/// <param name="index">The index of the character.</param>
+	/// <param name="item">The item.</param>
+	/// <returns>False if the buffer is out of bounds or an exception occured.</returns>
+	bool TryGetChar(int index, out TItem item);
 
-		/// <summary>
-		/// Counts the amount of items, starting from a given <paramref name="index"/>,
-		/// while a <paramref name="predicate"/> returns <c>true</c>.
-		/// </summary>
-		/// <param name="predicate">
-		/// A function that takes the current index (relative to <paramref name="index"/>),
-		/// which is incremented every item, and the item associated with it. Execution stops when
-		/// the predicate returns <c>false</c> or the index is out of bounds.
-		/// </param>
-		/// <param name="index">
-		/// The index at which to start counting; all indexes will also be given to the
-		/// <paramref name="predicate"/> as an offset that when added to the index of the position
-		/// equal the actual index.
-		/// </param>
-		/// <returns>The amount of items counted or -1 if out of bounds.</returns>
-		int CountWhile(Func<int, TItem, bool> predicate, int index);
+	/// <summary>
+	/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
+	/// If the <paramref name="index"/> is the start of a line, then that line is considered instead of the next.
+	/// The line might be empty if it's made up of line separators only.
+	/// No end of line characters are added.
+	/// </summary>
+	/// <param name="index">The index at which to determine what the next line is.</param>
+	/// <param name="line">The destination span that will contain the line.</param>
+	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
+	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
+	bool TryGetNextLineFrom(int index, Span<TItem> line, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the next item in the buffer, relative to an <paramref name="index"/>.
-		/// </summary>
-		/// <param name="index">The index of the character.</param>
-		/// <param name="item">The item.</param>
-		/// <returns>False if the buffer is out of bounds or an exception occured.</returns>
-		bool TryGetChar(int index, out TItem item);
+	/// <summary>
+	/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
+	/// If the <paramref name="index"/> is the start of a line, then that line is considered instead of the next.
+	/// If <paramref name="skipEmptyLines"/> is set to <c>true</c>, lines that only contain line separators will be
+	/// skipped, but lines containing non-line separator whitespace will not be skipped.
+	/// No end of line characters are added.
+	/// </summary>
+	/// <param name="index">The index at which to determine what the next line is.</param>
+	/// <param name="line">The destination span that will contain the line.</param>
+	/// <param name="skipEmptyLines">Whether to skip lines that are composed only of line separators.</param>
+	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
+	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
+	bool TryGetNextLineFrom(int index, Span<TItem> line, bool skipEmptyLines, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
-		/// If the <paramref name="index"/> is the start of a line, then that line is considered instead of the next.
-		/// The line might be empty if it's made up of line separators only.
-		/// No end of line characters are added.
-		/// </summary>
-		/// <param name="index">The index at which to determine what the next line is.</param>
-		/// <param name="line">The destination span that will contain the line.</param>
-		/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
-		/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-		bool TryGetNextLineFrom(int index, Span<TItem> line, out int itemCount);
+	/// <summary>
+	/// Tries to read the line that contains the item at <paramref name="index"/>.
+	/// No end of line characters are added.
+	/// </summary>
+	/// <param name="index">The index at which to determine what the current line is.</param>
+	/// <param name="line">The destination span that will contain the line.</param>
+	/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
+	/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
+	bool TryGetLineAt(int index, Span<TItem> line, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the next line in the buffer, relative to a given <paramref name="index"/>.
-		/// If the <paramref name="index"/> is the start of a line, then that line is considered instead of the next.
-		/// If <paramref name="skipEmptyLines"/> is set to <c>true</c>, lines that only contain line separators will be
-		/// skipped, but lines containing non-line separator whitespace will not be skipped.
-		/// No end of line characters are added.
-		/// </summary>
-		/// <param name="index">The index at which to determine what the next line is.</param>
-		/// <param name="line">The destination span that will contain the line.</param>
-		/// <param name="skipEmptyLines">Whether to skip lines that are composed only of line separators.</param>
-		/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
-		/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-		bool TryGetNextLineFrom(int index, Span<TItem> line, bool skipEmptyLines, out int itemCount);
+	/// <summary>
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of whitespace (if the starting index points to whitespace)
+	/// or a span of non-whitespace content (if the starting index does not point to whitespace).
+	/// </summary>
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="destination">The span which will be the destination for the read content.</param>
+	/// <param name="isWhitespace">True if the span is fully comprised of whitespace. If False, no whitespace is present.</param>
+	/// <param name="itemCount">The amount of characters that were written to <paramref name="destination"/>.</param>
+	/// <remarks>
+	/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
+	/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
+	/// will be set to something greater than <c>0</c>.
+	/// </remarks>
+	/// <returns>False if the buffer is out of bounds or an exception occured.</returns>
+	bool TryGetWord(int index, Span<TItem> destination, out bool isWhitespace, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the line that contains the item at <paramref name="index"/>.
-		/// No end of line characters are added.
-		/// </summary>
-		/// <param name="index">The index at which to determine what the current line is.</param>
-		/// <param name="line">The destination span that will contain the line.</param>
-		/// <param name="itemCount">The amount of items that were written to <paramref name="line"/>.</param>
-		/// <returns>False if the buffer is out of bounds, there are no more lines to read or an exception occured.</returns>
-		bool TryGetLineAt(int index, Span<TItem> line, out int itemCount);
+	/// <summary>
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of <paramref name="itemKind"/> (if the starting index
+	/// points to <paramref name="itemKind"/>) or a span of non-<paramref name="itemKind"/> content (if
+	/// the starting index does not point to <paramref name="itemKind"/>).
+	/// </summary>
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="itemKind">
+	/// The item that will serve as the delimiter. For example, if item kind is <c>,</c>, then 
+	/// the current word if the buffer is <c> My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
+	/// is <c> My awesome buffer</c>. If item kind is <c>;</c>, then 
+	/// the current word if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
+	/// </param>
+	/// <param name="destination">The span which will be the destination for the read content.</param>
+	/// <param name="isItemKind">
+	/// True if the span is fully comprised of <paramref name="itemKind"/>.
+	/// If False, no <paramref name="itemKind"/> is present.
+	/// </param>
+	/// <param name="itemCount">The amount of items that were written to <paramref name="destination"/>.</param>
+	/// <remarks>
+	/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
+	/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
+	/// will be set to something greater than <c>0</c>.
+	/// </remarks>
+	/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
+	bool TryGetWord(int index, TItem itemKind, Span<TItem> destination, out bool isItemKind, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the word at index <paramref name="index"/>, which can be a span of whitespace (if the starting index points to whitespace)
-		/// or a span of non-whitespace content (if the starting index does not point to whitespace).
-		/// </summary>
-		/// <param name="index">The index at which the word starts.</param>
-		/// <param name="destination">The span which will be the destination for the read content.</param>
-		/// <param name="isWhitespace">True if the span is fully comprised of whitespace. If False, no whitespace is present.</param>
-		/// <param name="itemCount">The amount of characters that were written to <paramref name="destination"/>.</param>
-		/// <remarks>
-		/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
-		/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
-		/// will be set to something greater than <c>0</c>.
-		/// </remarks>
-		/// <returns>False if the buffer is out of bounds or an exception occured.</returns>
-		bool TryGetWord(int index, Span<TItem> destination, out bool isWhitespace, out int itemCount);
+	/// <summary>
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of items verified by
+	/// <paramref name="itemKindPredicate"/> (if the starting index is verified by <paramref name="itemKindPredicate"/>)
+	/// or a span of content not verified by <paramref name="itemKindPredicate"/> (if
+	/// the starting index does not point to anything verified by <paramref name="itemKindPredicate"/>).
+	/// </summary>
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="itemKindPredicate">
+	/// A predicate that verifies if the first item in the selected range serves as the delimiter
+	/// (the predicate returns <c>true</c> if so). For example, if the predicate verifies <c>,</c>, then 
+	/// the current word if the buffer is <c>My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
+	/// is <c>My awesome buffer</c>. If the predicate verifies <c>;</c>, then the current word
+	/// if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
+	/// </param>
+	/// <param name="destination">The span which will be the destination for the read content.</param>
+	/// <param name="isItemKind">
+	/// True if the span is fully comprised of the item kind verified by <paramref name="itemKindPredicate"/>.
+	/// If False, no items verified by <paramref name="itemKindPredicate"/> is present.
+	/// </param>
+	/// <param name="itemCount">The amount of characters that were written to <paramref name="destination"/>.</param>
+	/// <remarks>
+	/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
+	/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
+	/// will be set to something greater than <c>0</c>.
+	/// </remarks>
+	/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
+	bool TryGetWord(int index, Func<int, TItem, bool> itemKindPredicate, Span<TItem> destination, out bool isItemKind, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the word at index <paramref name="index"/>, which can be a span of <paramref name="itemKind"/> (if the starting index
-		/// points to <paramref name="itemKind"/>) or a span of non-<paramref name="itemKind"/> content (if
-		/// the starting index does not point to <paramref name="itemKind"/>).
-		/// </summary>
-		/// <param name="index">The index at which the word starts.</param>
-		/// <param name="itemKind">
-		/// The item that will serve as the delimiter. For example, if item kind is <c>,</c>, then 
-		/// the current word if the buffer is <c> My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
-		/// is <c> My awesome buffer</c>. If item kind is <c>;</c>, then 
-		/// the current word if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
-		/// </param>
-		/// <param name="destination">The span which will be the destination for the read content.</param>
-		/// <param name="isItemKind">
-		/// True if the span is fully comprised of <paramref name="itemKind"/>.
-		/// If False, no <paramref name="itemKind"/> is present.
-		/// </param>
-		/// <param name="itemCount">The amount of items that were written to <paramref name="destination"/>.</param>
-		/// <remarks>
-		/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
-		/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
-		/// will be set to something greater than <c>0</c>.
-		/// </remarks>
-		/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
-		bool TryGetWord(int index, TItem itemKind, Span<TItem> destination, out bool isItemKind, out int itemCount);
+	/// <summary>
+	/// Given a 0-based line number, assigns the exact line to a result buffer (<paramref name="destination"/>).
+	/// </summary>
+	/// <param name="lineNumber">The 0-based line number.</param>
+	/// <param name="destination">The destination buffer for the line.</param>
+	/// <param name="itemCount">The amount of items returned.</param>
+	/// <returns>True if successful.</returns>
+	bool TryGetLine(int lineNumber, Span<TItem> destination, out int itemCount);
 
-		/// <summary>
-		/// Tries to read the word at index <paramref name="index"/>, which can be a span of items verified by
-		/// <paramref name="itemKindPredicate"/> (if the starting index is verified by <paramref name="itemKindPredicate"/>)
-		/// or a span of content not verified by <paramref name="itemKindPredicate"/> (if
-		/// the starting index does not point to anything verified by <paramref name="itemKindPredicate"/>).
-		/// </summary>
-		/// <param name="index">The index at which the word starts.</param>
-		/// <param name="itemKindPredicate">
-		/// A predicate that verifies if the first item in the selected range serves as the delimiter
-		/// (the predicate returns <c>true</c> if so). For example, if the predicate verifies <c>,</c>, then 
-		/// the current word if the buffer is <c>My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
-		/// is <c>My awesome buffer</c>. If the predicate verifies <c>;</c>, then the current word
-		/// if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
-		/// </param>
-		/// <param name="destination">The span which will be the destination for the read content.</param>
-		/// <param name="isItemKind">
-		/// True if the span is fully comprised of the item kind verified by <paramref name="itemKindPredicate"/>.
-		/// If False, no items verified by <paramref name="itemKindPredicate"/> is present.
-		/// </param>
-		/// <param name="itemCount">The amount of characters that were written to <paramref name="destination"/>.</param>
-		/// <remarks>
-		/// This method may lead to partial reading (for example if <paramref name="destination"/> is not
-		/// large enough). When this happens, the return value will be <strong>False</strong> but <paramref name="itemCount"/>
-		/// will be set to something greater than <c>0</c>.
-		/// </remarks>
-		/// <returns>False if the buffer is out of bounds, the reading was only partial or an exception occured.</returns>
-		bool TryGetWord(int index, Func<int, TItem, bool> itemKindPredicate, Span<TItem> destination, out bool isItemKind, out int itemCount);
+	/// <summary>
+	/// Counts the amount of items until the next non-whitespace item in the buffer, relative to a given <paramref name="index"/>.
+	/// Line separators are included in the whitespace category.
+	/// </summary>
+	/// <param name="index">The index at which to start counting.</param>
+	/// <returns>The index of the next non-whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
+	int CountUntilNotWhitespace(int index);
 
-		/// <summary>
-		/// Given a 0-based line number, assigns the exact line to a result buffer (<paramref name="destination"/>).
-		/// </summary>
-		/// <param name="lineNumber">The 0-based line number.</param>
-		/// <param name="destination">The destination buffer for the line.</param>
-		/// <param name="itemCount">The amount of items returned.</param>
-		/// <returns>True if successful.</returns>
-		bool TryGetLine(int lineNumber, Span<TItem> destination, out int itemCount);
+	/// <summary>
+	/// Slices a region of the buffer.
+	/// </summary>
+	/// <param name="start">The index of the first item in the slice.</param>
+	/// <param name="length">The amount of items to slice starting at <paramref name="start"/>.</param>
+	/// <returns>A slice, as an array of items.</returns>
+	TItem[] Slice(int start, int length);
 
-		/// <summary>
-		/// Counts the amount of items until the next non-whitespace item in the buffer, relative to a given <paramref name="index"/>.
-		/// Line separators are included in the whitespace category.
-		/// </summary>
-		/// <param name="index">The index at which to start counting.</param>
-		/// <returns>The index of the next non-whitespace item, relative to a <paramref name="index"/> or -1 if out of bounds.</returns>
-		int CountUntilNotWhitespace(int index);
+	/// <summary>
+	/// Slices a region of the buffer into a performant span.
+	/// </summary>
+	/// <param name="start">The index of the first item in the slice.</param>
+	/// <param name="slice">The span serving as the destination for the slice.</param>
+	void Slice(int start, Span<TItem> slice);
 
-		/// <summary>
-		/// Slices a region of the buffer.
-		/// </summary>
-		/// <param name="start">The index of the first item in the slice.</param>
-		/// <param name="length">The amount of items to slice starting at <paramref name="start"/>.</param>
-		/// <returns>A slice, as an array of items.</returns>
-		TItem[] Slice(int start, int length);
+	/// <summary>
+	/// Slices a region of the buffer into a performant span.
+	/// </summary>
+	/// <param name="sourceSpan">The span indicating what the slice is.</param>
+	/// <param name="slice">The span serving as the destination for the slice.</param>
+	void Slice(SourceSpan sourceSpan, Span<TItem> slice);
 
-		/// <summary>
-		/// Slices a region of the buffer into a performant span.
-		/// </summary>
-		/// <param name="start">The index of the first item in the slice.</param>
-		/// <param name="slice">The span serving as the destination for the slice.</param>
-		void Slice(int start, Span<TItem> slice);
-
-		/// <summary>
-		/// Slices a region of the buffer into a performant span.
-		/// </summary>
-		/// <param name="sourceSpan">The span indicating what the slice is.</param>
-		/// <param name="slice">The span serving as the destination for the slice.</param>
-		void Slice(SourceSpan sourceSpan, Span<TItem> slice);
-
-		/// <summary>
-		/// Gets a single item out of the buffer.
-		/// </summary>
-		/// <param name="index">The index of the item to retrieve.</param>
-		/// <returns>The item.</returns>
-		TItem this[int index] { get; }
-
-	}
-
+	/// <summary>
+	/// Gets a single item out of the buffer.
+	/// </summary>
+	/// <param name="index">The index of the item to retrieve.</param>
+	/// <returns>The item.</returns>
+	TItem this[int index] { get; }
 }

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 
 using OceanApocalypseStudios.RSML.Common;
+using OceanApocalypseStudios.RSML.Exceptions;
 
 
 namespace OceanApocalypseStudios.RSML.Sources.Buffers;
@@ -21,10 +22,13 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	private readonly string data;
 
 	/// <inheritdoc/>
-	public int Length => data.Length;
+	public bool CacheExists { get; private set; } = false;
 
 	/// <inheritdoc/>
 	public bool IsEmpty => Length == 0;
+
+	/// <inheritdoc/>
+	public int Length => data.Length;
 
 	/// <inheritdoc/>
 	public int LineCount
@@ -36,9 +40,6 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return lineStarts.Count;
 		}
 	}
-
-	/// <inheritdoc/>
-	public bool CacheExists { get; private set; } = false;
 
 	/// <inheritdoc/>
 	public char this[int index] => data[index];
@@ -91,187 +92,11 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public unsafe ReadOnlyStringBuffer(byte* contentPtr, int byteCount, Encoding? encoding = null) =>
 		data = (encoding ?? Encoding.Default).GetString(contentPtr, byteCount);
 
-	private int GetNextLineStartPosition(int index, out int lsListIndex) =>
-		// we use index + 1 to skip to the next line start if we're already standing on one :)
-		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index + 1), out lsListIndex);
-
-	/// <summary>
-	/// Shared code context for <see cref="GetNextLineStartPosition(Int32, out Int32)"/> and
-	/// <see cref="GetNextOrCurrentLineStartPosition(Int32, out Int32)"/>.
-	/// </summary>
-	/// <param name="insertionPoint">The insertion point of the next line start.</param>
-	/// <param name="lsListIndex">The index, in <see cref="lineStarts"/> where the line start is.</param>
-	/// <returns>The line start index, in <see cref="data"/>.</returns>
-	private int GetNextLineStartFromInsertionPoint(int insertionPoint, out int lsListIndex)
-	{
-		if (insertionPoint >= 0)
-		{
-			// 1st Case: the used index (might have been index + 1 based on the method that called this)
-			// points to an actual line start
-			lsListIndex = insertionPoint;
-			return lineStarts[insertionPoint];
-		}
-
-		int nextIndex = ~insertionPoint;
-
-		if (nextIndex == lineStarts.Count)
-		{
-			// 2nd Case: the next line start is outside of the buffer (EOF convention)
-			lsListIndex = -1;
-			return data.Length;
-		}
-
-		lsListIndex = nextIndex;
-
-		return lineStarts[nextIndex]; // 3rd Case: we found the next line start
-	}
-
-	private int GetNextOrCurrentLineStartPosition(int index, out int lsListIndex) =>
-		// we use the actual index because we might already be standing on the line start
-		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
-
-	/// <summary>
-	/// Shared code context for <see cref="GetPreviousLineStartPosition(Int32, out Int32)"/> and
-	/// <see cref="GetPreviousOrCurrentLineStartPosition(Int32, out Int32)"/>.
-	/// </summary>
-	/// <param name="insertionPoint">The insertion point of the next line start.</param>
-	/// <param name="lsListIndex">The index, in <see cref="lineStarts"/> where the line start is.</param>
-	/// <returns>The line start index, in <see cref="data"/>.</returns>
-	private int GetPreviousLineStartFromInsertionPoint(int insertionPoint, out int lsListIndex)
-	{
-		if (insertionPoint >= 0)
-		{
-			// 1st Case: the used index (might have been index + 1 based on the method that called this)
-			// points to an actual line start
-			lsListIndex = insertionPoint;
-			return lineStarts[insertionPoint];
-		}
-
-		int nextIndex = ~insertionPoint;
-
-		if (nextIndex == lineStarts.Count)
-		{
-			// 2nd Case: the next line start is outside of the buffer (EOF convention)
-			lsListIndex = -1;
-			return data.Length;
-		}
-
-		lsListIndex = nextIndex < 0 ? 0 : nextIndex - 1;
-
-		return lineStarts[lsListIndex]; // 3rd Case: we found the previous line start
-	}
-
-	private int GetPreviousLineStartPosition(int index, out int lsListIndex)
-	{
-		if (index > 0)
-		{
-			// when the index is greater than 0, we can safely get the previous line start without getting a big shitty error
-			// we use 0 as the start following standard conventions
-			return GetPreviousLineStartFromInsertionPoint(lineStarts.BinarySearch(index - 1), out lsListIndex);
-		}
-
-		lsListIndex = 0;
-		return 0;
-	}
-
-	private int GetPreviousOrCurrentLineStartPosition(int index, out int lsListIndex)
-	{
-		if (index > 0)
-		{
-			// when the index is greater than 0, we can safely get the previous line start without getting a big shitty error
-			// we use 0 as the start following standard conventions
-			return GetPreviousLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
-		}
-
-		lsListIndex = 0;
-		return 0;
-	}
-
-	private void ComputeLineStarts(bool forceCache = false)
-	{
-		if (CacheExists && !forceCache)
-			return;
-
-		var span = data.AsSpan();
-
-		lineStarts.Clear();
-		precededByCrLf.Clear();
-
-		lineStarts.Capacity = Math.Max(lineStarts.Capacity, span.Length / 25 + 32); // just a rough guess
-		precededByCrLf.Capacity = Math.Max(precededByCrLf.Capacity, span.Length / 25 + 16); // just a rough guess
-
-		int lastIndex = span.Length - 1;
-		int i = 0;
-
-		while (i < span.Length)
-		{
-			if (!span[i].IsNewline())
-			{
-				i++;
-				continue;
-			}
-
-			bool isCrLf = i < lastIndex && span[i] == '\r' && span[i + 1] == '\n';
-			int nextStart = i + (isCrLf ? 2 : 1);
-			lineStarts.Add(nextStart);
-
-			if (isCrLf)
-				precededByCrLf.Add(nextStart);
-
-			i = nextStart;
-		}
-
-		CacheExists = true;
-	}
+	/// <inheritdoc/>
+	public void BuildCache() => ComputeLineStarts();
 
 	/// <inheritdoc/>
-	public int CountUntilWhitespace(int index)
-	{
-		if (IsEmpty)
-			return 0;
-
-		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
-
-		if (IsOutOfBounds(index))
-			return -1;
-
-		var span = data.AsSpan(index);
-		int count = 0;
-
-		while (count < span.Length && !Char.IsWhiteSpace(span[count]))
-			count++;
-
-		return count;
-	}
-
-	private int CountUntilMatch(int index, char character)
-	{
-		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
-
-		var span = data.AsSpan(index);
-		int count = 0;
-
-		while (count < span.Length && span[count] == character)
-			count++;
-
-		return count;
-	}
-
-	private int CountUntilNotMatch(int index, char character)
-	{
-		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
-
-		var span = data.AsSpan(index);
-		int count = 0;
-
-		while (count < span.Length && span[count] != character)
-			count++;
-
-		return count;
-	}
+	public void BuildCache(bool forceRebuild) => ComputeLineStarts(forceRebuild);
 
 	/// <inheritdoc/>
 	public int CountUntilLineSeparator(int index, out bool isCrLf)
@@ -284,7 +109,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfBounds(index))
+		if (IsOutOfRange(index))
 			return -1;
 
 		if (data[index].IsNewline())
@@ -298,20 +123,47 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		return lineSep - index;
 	}
 
-	/// <remarks>
-	/// Ignores the LF in CRLF sequences (returns the CR if the matching sequence is CRLF) - avoid double counting and other issues.
-	/// </remarks>
-	private int ReverseCountUntilNewline(int index)
+	/// <inheritdoc/>
+	public int CountUntilNotWhitespace(int index)
 	{
+		if (IsEmpty)
+			return 0;
+
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		ComputeLineStarts();
+		if (IsOutOfRange(index))
+			return -1;
 
-		return index - GetPreviousLineStartPosition(index, out _);
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && Char.IsWhiteSpace(span[count]))
+			count++;
+
+		return count;
 	}
 
-	private bool IsOutOfBounds(int index) => index >= data.Length;
+	/// <inheritdoc/>
+	public int CountUntilWhitespace(int index)
+	{
+		if (IsEmpty)
+			return 0;
+
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		if (IsOutOfRange(index))
+			return -1;
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && !Char.IsWhiteSpace(span[count]))
+			count++;
+
+		return count;
+	}
 
 	/// <inheritdoc/>
 	public int CountWhile(Func<int, char, bool> predicate, int index)
@@ -322,7 +174,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfBounds(index))
+		if (IsOutOfRange(index))
 			return -1;
 
 		var span = data.AsSpan(index);
@@ -332,6 +184,55 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			count++;
 
 		return count;
+	}
+
+	public int GetLengthOfLine(int lineNumber)
+	{
+		// todo: this should return the exact length of a line (#54)
+		throw new NotImplementedException();
+	}
+
+	public int GetLengthOfLineAt(int index)
+	{
+		// todo: this should return the exact length of a line (#54)
+		throw new NotImplementedException();
+	}
+
+	/// <exception cref="BufferException">
+	/// The buffer is empty.
+	/// </exception>
+	/// <exception cref="IndexOutOfRangeException">
+	/// <paramref name="index"/> was set to something greater than the buffer's length.
+	/// </exception>
+	/// <inheritdoc/>
+	public int GetLineNumberAt(int index)
+	{
+		if (IsEmpty)
+			throw new BufferException("Buffer cannot be empty.");
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsConventionallyOutOfRange(index))
+			throw new IndexOutOfRangeException("Index must be less than the buffer's length in this context.");
+
+		GetPreviousOrCurrentLineStartPosition(index, out int lineSepIndex);
+		return lineSepIndex;
+	}
+
+	/// <inheritdoc/>
+	public char[] Slice(int start, int length) => data.ToCharArray(start, length);
+
+	/// <inheritdoc/>
+	public void Slice(int start, Span<char> slice) => data.AsSpan(start, slice.Length).CopyTo(slice);
+
+	/// <inheritdoc/>
+	public void Slice(SourceSpan sourceSpan, Span<char> slice)
+	{
+		if (slice.Length < sourceSpan.Length)
+			throw new ArgumentException("The slice's length is less than the span's length and therefore cannot contain the sliced region.", nameof(slice));
+
+		data.AsSpan(sourceSpan.Start.Index, sourceSpan.Length).CopyTo(slice);
 	}
 
 	/// <inheritdoc/>
@@ -345,211 +246,12 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfBounds(index))
+		if (IsOutOfRange(index))
 			return false;
 
 		item = data[index];
 
 		return true;
-	}
-
-	/// <inheritdoc/>
-	public bool TryGetNextLineFrom(int index, Span<char> line, out int itemCount)
-	{
-		itemCount = 0;
-
-		if (IsEmpty)
-			return false;
-
-		if (index < 0)
-			index += data.Length;
-
-		if (IsOutOfBounds(index))
-			return false;
-
-		ComputeLineStarts();
-
-		if (precededByCrLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
-			index--;                            // use the CR in the CRLF sequence instead of using the LF
-
-		index += CountUntilLineSeparator(index, out bool isCrLf); // skip to the next line separator
-		index += isCrLf ? 2 : 1; // skip to the actual start of the next line (skip twice if CRLF)
-
-		if (IsOutOfBounds(index))
-			return false;
-
-		// when summed with the index, returns the line separator index - which must be excluded from the return value
-		int actualLineLength = CountUntilLineSeparator(index, out _);
-		int charsToCopyAmount = Math.Min(actualLineLength, line.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(line);
-
-		itemCount = charsToCopyAmount;
-
-		return line.Length >= actualLineLength;
-	}
-
-	/// <inheritdoc/>
-	public bool TryGetWord(int index, Span<char> destination, out bool isWhitespace, out int itemCount)
-	{
-		isWhitespace = false;
-		itemCount = 0;
-
-		if (IsEmpty)
-			return false;
-
-		if (index < 0)
-			index += data.Length;
-
-		if (IsOutOfBounds(index))
-			return false;
-
-		isWhitespace = Char.IsWhiteSpace(data[index]);
-
-		// if first index is whitespace, the word is whitespace (ends when not whitespace/end of buffer)
-		// if first index not whitespace, the word is not whitespace (ends on whitespace/end of buffer)
-		int actualLineLength = isWhitespace
-								   ? CountUntilNotWhitespace(index)
-								   : CountUntilWhitespace(index);
-
-		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-		itemCount = charsToCopyAmount;
-
-		return destination.Length >= actualLineLength;
-	}
-
-	/// <inheritdoc/>
-	public bool TryGetWord(int index, char itemKind, Span<char> destination, out bool isItemKind, out int itemCount)
-	{
-		isItemKind = false;
-		itemCount = 0;
-
-		if (IsEmpty)
-			return false;
-
-		if (index < 0)
-			index += data.Length;
-
-		if (IsOutOfBounds(index))
-			return false;
-
-		isItemKind = data[index] == itemKind;
-
-		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
-		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-		int actualLineLength = isItemKind
-								   ? CountUntilNotMatch(index, itemKind)
-								   : CountUntilMatch(index, itemKind);
-
-		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-		itemCount = charsToCopyAmount;
-
-		return destination.Length >= actualLineLength;
-	}
-
-	/// <inheritdoc/>
-	public int CountUntilNotWhitespace(int index)
-	{
-		if (IsEmpty)
-			return 0;
-
-		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
-
-		if (IsOutOfBounds(index))
-			return -1;
-
-		var span = data.AsSpan(index);
-		int count = 0;
-
-		while (count < span.Length && Char.IsWhiteSpace(span[count]))
-			count++;
-
-		return count;
-	}
-
-	/// <inheritdoc/>
-	public char[] Slice(int start, int length) => data.ToCharArray(start, length);
-
-	/// <inheritdoc/>
-	public void Dispose() => GC.SuppressFinalize(this);
-
-	/// <inheritdoc/>
-	public bool TryGetWord(int index, Func<int, char, bool> itemKindPredicate, Span<char> destination, out bool isItemKind, out int itemCount)
-	{
-		isItemKind = false;
-		itemCount = 0;
-
-		if (IsEmpty)
-			return false;
-
-		if (index < 0)
-			index += data.Length;
-
-		if (IsOutOfBounds(index))
-			return false;
-
-		isItemKind = itemKindPredicate(index, data[index]);
-
-		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
-		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-		int actualLineLength = isItemKind
-								   ? CountWhile((i, c) => !itemKindPredicate(i, c), index)
-								   : CountWhile(itemKindPredicate, index);
-
-		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-		itemCount = charsToCopyAmount;
-
-		return destination.Length >= actualLineLength;
-	}
-
-	/// <inheritdoc/>
-	public void Slice(int start, Span<char> slice) => data.AsSpan(start, slice.Length).CopyTo(slice);
-
-	/// <remarks>
-	/// This implementation, unlike others, is official and does not suffer from major performance issues.
-	/// </remarks>
-	/// <inheritdoc/>
-	public bool TryGetSourceLocation(int index, out SourceLocation location)
-	{
-		location = new();
-
-		if (IsEmpty)
-			return false;
-
-		if (index < 0)
-			index += data.Length;
-
-		if (IsOutOfBounds(index))
-			return false;
-
-		if (index == 0) // best "best" case = triple zero
-		{
-			location = new(0, 0, 0);
-
-			return true;
-		}
-
-		ComputeLineStarts();
-
-		location = new(index, CountLinesBefore(index), ReverseCountUntilNewline(index));
-
-		return true;
-	}
-
-	internal int CountLinesBefore(int index)
-	{
-		if (index == data.Length - 1)
-			return LineCount;
-
-		GetPreviousOrCurrentLineStartPosition(index, out int lineSepIndex);
-
-		return lineSepIndex + 1; // the amount of lines is the amount of line separators plus 1 ALWAYS
 	}
 
 	/// <inheritdoc/>
@@ -596,11 +298,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (index < 0)
 			index += data.Length;
 
-		if (IsOutOfBounds(index))
+		if (IsOutOfRange(index))
 			return false;
 
 		ComputeLineStarts();
-
 		int spanStart = GetPreviousLineStartPosition(index, out int lineSepBeforeIndex);
 
 		if (lineSepBeforeIndex != -1) // only skip necessary characters if the start of the span isn't 0
@@ -629,24 +330,38 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	}
 
 	/// <inheritdoc/>
-	public void Slice(SourceSpan sourceSpan, Span<char> slice)
+	public bool TryGetNextLineFrom(int index, Span<char> line, out int itemCount)
 	{
-		if (slice.Length < sourceSpan.Length)
-			throw new ArgumentException("The slice's length is less than the span's length and therefore cannot contain the sliced region.", nameof(slice));
+		itemCount = 0;
 
-		data.AsSpan(sourceSpan.Start.Index, sourceSpan.Length).CopyTo(slice);
-	}
+		if (IsEmpty)
+			return false;
 
-	public int GetLengthOfLine(int lineNumber)
-	{
-		// todo: this should return the exact length of a line (#54)
-		throw new NotImplementedException();
-	}
+		if (index < 0)
+			index += data.Length;
 
-	public int GetLengthOfLineAt(int index)
-	{
-		// todo: this should return the exact length of a line (#54)
-		throw new NotImplementedException();
+		if (IsOutOfRange(index))
+			return false;
+
+		ComputeLineStarts();
+
+		if (precededByCrLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
+			index--;                            // use the CR in the CRLF sequence instead of using the LF
+
+		index += CountUntilLineSeparator(index, out bool isCrLf); // skip to the next line separator
+		index += isCrLf ? 2 : 1; // skip to the actual start of the next line (skip twice if CRLF)
+
+		if (IsOutOfRange(index))
+			return false;
+
+		// when summed with the index, returns the line separator index - which must be excluded from the return value
+		int actualLineLength = CountUntilLineSeparator(index, out _);
+		int charsToCopyAmount = Math.Min(actualLineLength, line.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(line);
+
+		itemCount = charsToCopyAmount;
+
+		return line.Length >= actualLineLength;
 	}
 
 	/// <inheritdoc/>
@@ -658,11 +373,132 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		throw new NotImplementedException();
 	}
 
+	/// <remarks>
+	/// This implementation, unlike others, is official and does not suffer from major performance issues.
+	/// </remarks>
 	/// <inheritdoc/>
-	public void BuildCache() => ComputeLineStarts();
+	public bool TryGetSourceLocation(int index, out SourceLocation location)
+	{
+		location = new();
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfRange(index))
+			return false;
+
+		if (index == 0) // best "best" case = triple zero
+		{
+			location = new(0, 0, 0);
+
+			return true;
+		}
+
+		ComputeLineStarts();
+
+		location = new(index, GetLineNumberAt(index), ReverseCountUntilNewline(index));
+
+		return true;
+	}
 
 	/// <inheritdoc/>
-	public void BuildCache(bool forceRebuild) => ComputeLineStarts(forceRebuild);
+	public bool TryGetWord(int index, char itemKind, Span<char> destination, out bool isItemKind, out int itemCount)
+	{
+		isItemKind = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfRange(index))
+			return false;
+
+		isItemKind = data[index] == itemKind;
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int actualLineLength = isItemKind
+								   ? CountUntilNotMatch(index, itemKind)
+								   : CountUntilMatch(index, itemKind);
+
+		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
+
+		itemCount = charsToCopyAmount;
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetWord(int index, Span<char> destination, out bool isWhitespace, out int itemCount)
+	{
+		isWhitespace = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfRange(index))
+			return false;
+
+		isWhitespace = Char.IsWhiteSpace(data[index]);
+
+		// if first index is whitespace, the word is whitespace (ends when not whitespace/end of buffer)
+		// if first index not whitespace, the word is not whitespace (ends on whitespace/end of buffer)
+		int actualLineLength = isWhitespace
+								   ? CountUntilNotWhitespace(index)
+								   : CountUntilWhitespace(index);
+
+		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
+
+		itemCount = charsToCopyAmount;
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetWord(int index, Func<int, char, bool> itemKindPredicate, Span<char> destination, out bool isItemKind, out int itemCount)
+	{
+		isItemKind = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfRange(index))
+			return false;
+
+		isItemKind = itemKindPredicate(index, data[index]);
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int actualLineLength = isItemKind
+								   ? CountWhile((i, c) => !itemKindPredicate(i, c), index)
+								   : CountWhile(itemKindPredicate, index);
+
+		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
+
+		itemCount = charsToCopyAmount;
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public void Dispose() => GC.SuppressFinalize(this);
 
 	/// <inheritdoc/>
 #if NET10_0_OR_GREATER
@@ -673,17 +509,19 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		Equals(obj as ReadOnlyStringBuffer);
 
 	/// <summary>
-	/// Returns the buffer's content as a <see cref="String"/>.
+	/// Checks if another read-only buffer is equal to the current instance.
 	/// </summary>
-	/// <returns>The buffer's content.</returns>
-	public override string ToString() => data;
+	/// <param name="other">The other read-only buffer.</param>
+	/// <returns>True if equals.</returns>
+	public bool Equals(IReadOnlyBuffer<char>? other) => other is ReadOnlyStringBuffer buffer && Equals(buffer);
 
 	/// <summary>
 	/// Checks if another read-only string buffer is equal to the current instance.
 	/// </summary>
 	/// <param name="other">The other read-only string buffer.</param>
 	/// <returns>True if equals.</returns>
-	public bool Equals(ReadOnlyStringBuffer? other) => other is not null && data == other.data && Length == other.Length && IsEmpty == other.IsEmpty && LineCount == other.LineCount;
+	public bool Equals(ReadOnlyStringBuffer? other) =>
+		other is not null && data == other.data && Length == other.Length && IsEmpty == other.IsEmpty && LineCount == other.LineCount;
 
 	/// <inheritdoc/>
 	public override int GetHashCode()
@@ -698,11 +536,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	}
 
 	/// <summary>
-	/// Checks if another read-only buffer is equal to the current instance.
+	/// Returns the buffer's content as a <see cref="String"/>.
 	/// </summary>
-	/// <param name="other">The other read-only buffer.</param>
-	/// <returns>True if equals.</returns>
-	public bool Equals(IReadOnlyBuffer<char>? other) => other is ReadOnlyStringBuffer buffer && Equals(buffer);
+	/// <returns>The buffer's content.</returns>
+	public override string ToString() => data;
 
 	/// <summary>
 	/// Checks if two read-only string buffers are equals.
@@ -716,4 +553,195 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	/// </summary>
 	/// <returns>True if different.</returns>
 	public static bool operator !=(ReadOnlyStringBuffer left, ReadOnlyStringBuffer right) => !(left == right);
+
+	private void ComputeLineStarts(bool forceCache = false)
+	{
+		if (CacheExists && !forceCache)
+			return;
+
+		var span = data.AsSpan();
+
+		lineStarts.Clear();
+		precededByCrLf.Clear();
+
+		lineStarts.Capacity = Math.Max(lineStarts.Capacity, span.Length / 25 + 32); // just a rough guess
+		precededByCrLf.Capacity = Math.Max(precededByCrLf.Capacity, span.Length / 25 + 16); // just a rough guess
+
+		int lastIndex = span.Length - 1;
+		int i = 0;
+
+		lineStarts.Add(0); // 0 is by convention the start of line (and also the start of the buffer)
+
+		while (i < lastIndex)
+		{
+			if (!span[i].IsNewline())
+			{
+				i++;
+				continue;
+			}
+
+			bool isCrLf = i < lastIndex && span[i] == '\r' && span[i + 1] == '\n';
+			int nextStart = i + (isCrLf ? 2 : 1);
+			lineStarts.Add(nextStart);
+
+			if (isCrLf)
+				precededByCrLf.Add(nextStart);
+
+			i = nextStart;
+		}
+
+		CacheExists = true;
+	}
+
+	private int CountUntilMatch(int index, char character)
+	{
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && span[count] == character)
+			count++;
+
+		return count;
+	}
+
+	private int CountUntilNotMatch(int index, char character)
+	{
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && span[count] != character)
+			count++;
+
+		return count;
+	}
+
+	/// <summary>
+	/// Shared code context for <see cref="GetNextLineStartPosition(Int32, out Int32)"/> and
+	/// <see cref="GetNextOrCurrentLineStartPosition(Int32, out Int32)"/>.
+	/// </summary>
+	/// <param name="insertionPoint">The insertion point of the next line start.</param>
+	/// <param name="lsListIndex">The index, in <see cref="lineStarts"/> where the line start is.</param>
+	/// <returns>The line start index, in <see cref="data"/>.</returns>
+	private int GetNextLineStartFromInsertionPoint(int insertionPoint, out int lsListIndex)
+	{
+		if (insertionPoint >= 0)
+		{
+			// 1st Case: the used index (might have been index + 1 based on the method that called this)
+			// points to an actual line start
+			lsListIndex = insertionPoint;
+			return lineStarts[insertionPoint];
+		}
+
+		int nextIndex = ~insertionPoint;
+
+		if (nextIndex == lineStarts.Count)
+		{
+			// 2nd Case: the next line start is outside of the buffer (EOF convention)
+			lsListIndex = -1;
+			return data.Length;
+		}
+
+		lsListIndex = nextIndex;
+
+		return lineStarts[nextIndex]; // 3rd Case: we found the next line start
+	}
+
+	private int GetNextLineStartPosition(int index, out int lsListIndex) =>
+		// we use index + 1 to skip to the next line start if we're already standing on one :)
+		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index + 1), out lsListIndex);
+	private int GetNextOrCurrentLineStartPosition(int index, out int lsListIndex) =>
+		// we use the actual index because we might already be standing on the line start
+		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
+
+	/// <summary>
+	/// Shared code context for <see cref="GetPreviousLineStartPosition(Int32, out Int32)"/> and
+	/// <see cref="GetPreviousOrCurrentLineStartPosition(Int32, out Int32)"/>.
+	/// </summary>
+	/// <param name="insertionPoint">The insertion point of the next line start.</param>
+	/// <param name="lsListIndex">The index, in <see cref="lineStarts"/> where the line start is.</param>
+	/// <returns>The line start index, in <see cref="data"/>.</returns>
+	private int GetPreviousLineStartFromInsertionPoint(int insertionPoint, out int lsListIndex)
+	{
+		if (insertionPoint >= 0)
+		{
+			// 1st Case: the used index (might have been index + 1 based on the method that called this)
+			// points to an actual line start
+			lsListIndex = insertionPoint;
+			return lineStarts[insertionPoint];
+		}
+
+		int previousIndex = ~insertionPoint;
+
+		if (previousIndex == lineStarts.Count)
+		{
+			// 2nd Case: the next line start is outside of the buffer (EOF convention)
+			lsListIndex = previousIndex;
+			return data.Length;
+		}
+
+		lsListIndex = previousIndex == 0 ? 0 : previousIndex - 1;
+
+		return lineStarts[lsListIndex]; // 3rd Case: we found the previous line start
+	}
+
+	private int GetPreviousLineStartPosition(int index, out int lsListIndex)
+	{
+		if (index > 0)
+		{
+			// when the index is greater than 0, we can safely get the previous line start without getting a big shitty error
+			// we use 0 as the start following standard conventions
+			return GetPreviousLineStartFromInsertionPoint(lineStarts.BinarySearch(index - 1), out lsListIndex);
+		}
+
+		lsListIndex = 0;
+		return 0;
+	}
+
+	private int GetPreviousOrCurrentLineStartPosition(int index, out int lsListIndex)
+	{
+		if (index > 0)
+		{
+			// when the index is greater than 0, we can safely get the previous line start without getting a big shitty error
+			// we use 0 as the start following standard conventions
+			return GetPreviousLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
+		}
+
+		lsListIndex = 0;
+		return 0;
+	}
+
+	/// <summary>
+	/// True if index is greater than the length.
+	/// This allows for the EOF convention, where the EOF is a possible output for
+	/// some methods.
+	/// Does not protect against <see cref="ArgumentOutOfRangeException"/> and
+	/// <see cref="IndexOutOfRangeException"/>.
+	/// </summary>
+	private bool IsConventionallyOutOfRange(int index) => index > data.Length;
+
+	/// <summary>
+	/// True if index is greater than or equal to the length.
+	/// This prevents throwing <see cref="ArgumentOutOfRangeException"/>
+	/// or <see cref="IndexOutOfRangeException"/>.
+	/// </summary>
+	private bool IsOutOfRange(int index) => index >= data.Length;
+
+	/// <remarks>
+	/// Ignores the LF in CRLF sequences (returns the CR if the matching sequence is CRLF) - avoid double counting and other issues.
+	/// </remarks>
+	private int ReverseCountUntilNewline(int index)
+	{
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		ComputeLineStarts();
+
+		return index - GetPreviousLineStartPosition(index, out _);
+	}
 }

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -12,11 +12,14 @@ namespace OceanApocalypseStudios.RSML.Sources.Buffers;
 /// primarily via the internal use of <see cref="Span{Char}"/> over string allocations
 /// and also via caching.
 /// </summary>
-public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
+public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
+									ISupportsCache
 {
-	readonly List<int> lineSeparators = [];
-	readonly List<int> crFollowedByLf = [];
-	readonly string data;
+	private readonly List<int> lineSeparators = [ ];
+
+	private readonly List<int> crFollowedByLf = [ ];
+
+	private readonly string data;
 
 	/// <inheritdoc/>
 	public int Length => data.Length;
@@ -30,6 +33,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 		get
 		{
 			ComputeLineSeparators();
+
 			return lineSeparators.Count;
 		}
 	}
@@ -85,7 +89,8 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 	/// </param>
 	/// <remarks>This method is not CLS-compliant due to the unsafe context and the use of pointers.</remarks>
 	[CLSCompliant(false)]
-	public unsafe ReadOnlyStringBuffer(byte* contentPtr, int byteCount, Encoding? encoding = null) => data = encoding?.GetString(contentPtr, byteCount) ?? Encoding.Default.GetString(contentPtr, byteCount);
+	public unsafe ReadOnlyStringBuffer(byte* contentPtr, int byteCount, Encoding? encoding = null) =>
+		data = encoding?.GetString(contentPtr, byteCount) ?? Encoding.Default.GetString(contentPtr, byteCount);
 
 	private int GetLineSeparatorAfter(int index, out int lsListIndex)
 	{
@@ -232,7 +237,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 			return 0;
 
 		ComputeLineSeparators();
-		var lineSep = GetLineSeparatorAfter(index, out _);
+		int lineSep = GetLineSeparatorAfter(index, out _);
 
 		isCrLf = crFollowedByLf.Contains(lineSep);
 
@@ -290,6 +295,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 			return false;
 
 		item = data[index];
+
 		return true;
 	}
 
@@ -312,7 +318,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 		ComputeLineSeparators();
 
 		if (crFollowedByLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
-			index--; // use the CR in the CRLF sequence instead of using the LF
+			index--;                            // use the CR in the CRLF sequence instead of using the LF
 
 		index += CountUntilLineSeparator(index, out bool isCrLf); // skip to the next line separator
 		index += isCrLf ? 2 : 1; // skip to the actual start of the next line (skip twice if CRLF)
@@ -321,8 +327,8 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 			return false;
 
 		// when summed with the index, returns the line separator index - which must be excluded from the return value
-		var actualLineLength = CountUntilLineSeparator(index, out _);
-		var charsToCopyAmount = Math.Min(actualLineLength, line.Length);
+		int actualLineLength = CountUntilLineSeparator(index, out _);
+		int charsToCopyAmount = Math.Min(actualLineLength, line.Length);
 		data.AsSpan(index, charsToCopyAmount).CopyTo(line);
 
 		itemCount = charsToCopyAmount;
@@ -349,7 +355,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 
 		// if first index is whitespace, the word is whitespace (ends when not whitespace/end of buffer)
 		// if first index not whitespace, the word is not whitespace (ends on whitespace/end of buffer)
-		int actualLineLength = isWhitespace ? CountUntilNotWhitespace(index) : CountUntilWhitespace(index);
+		int actualLineLength = isWhitespace
+								   ? CountUntilNotWhitespace(index)
+								   : CountUntilWhitespace(index);
+
 		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
 		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
 
@@ -377,7 +386,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 
 		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
 		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-		int actualLineLength = isItemKind ? CountUntilNotMatch(index, itemKind) : CountUntilMatch(index, itemKind);
+		int actualLineLength = isItemKind
+								   ? CountUntilNotMatch(index, itemKind)
+								   : CountUntilMatch(index, itemKind);
+
 		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
 		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
 
@@ -432,7 +444,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 
 		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
 		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-		int actualLineLength = isItemKind ? CountWhile((i, c) => !itemKindPredicate(i, c), index) : CountWhile(itemKindPredicate, index);
+		int actualLineLength = isItemKind
+								   ? CountWhile((i, c) => !itemKindPredicate(i, c), index)
+								   : CountWhile(itemKindPredicate, index);
+
 		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
 		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
 
@@ -464,12 +479,14 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 		if (index == 0) // best "best" case = triple zero
 		{
 			location = new(0, 0, 0);
+
 			return true;
 		}
 
 		ComputeLineSeparators();
 
 		location = new(index, CountLinesBefore(index), ReverseCountUntilNewline(index));
+
 		return true;
 	}
 
@@ -496,16 +513,19 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 		if (lineNumber >= lineSeparators.Count)
 			return false;
 
-		var spanEnd = lineSeparators[lineNumber];
-		var spanStartIndex = lineNumber == 0 ? 0 : (lineNumber - 1);
+		int spanEnd = lineSeparators[lineNumber];
+
+		int spanStartIndex = lineNumber == 0
+								 ? 0
+								 : lineNumber - 1;
 
 		if (crFollowedByLf.Contains(lineSeparators[spanStartIndex]))
 			spanStartIndex++; // skip past the CR in the CRLF sequence
 
 		spanStartIndex++; // get the actual start of the next line instead of the line sep
 
-		var spanStart = lineSeparators[spanStartIndex];
-		var actualLineLength = spanEnd - spanStart + 1;
+		int spanStart = lineSeparators[spanStartIndex];
+		int actualLineLength = spanEnd - spanStart + 1;
 		itemCount = Math.Min(actualLineLength, destination.Length);
 
 		data.AsSpan(spanStart, itemCount).CopyTo(destination);
@@ -548,7 +568,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 		if (spanStart < spanEnd)
 			spanStart = spanEnd; // empty span
 
-		var actualLineLength = spanEnd - spanStart + 1;
+		int actualLineLength = spanEnd - spanStart + 1;
 		itemCount = Math.Min(actualLineLength, line.Length);
 
 		data.AsSpan(spanStart, itemCount).CopyTo(line);

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 using OceanApocalypseStudios.RSML.Common;
@@ -12,12 +13,11 @@ namespace OceanApocalypseStudios.RSML.Sources.Buffers;
 /// primarily via the internal use of <see cref="Span{Char}"/> over string allocations
 /// and also via caching.
 /// </summary>
-public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
-									ISupportsCache
+public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEquatable<ReadOnlyStringBuffer?>
 {
-	private readonly List<int> lineSeparators = [ ];
+	private readonly List<int> lineStarts = [];
 
-	private readonly List<int> crFollowedByLf = [ ];
+	private readonly List<int> precededByCrLf = [];
 
 	private readonly string data;
 
@@ -32,9 +32,9 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 	{
 		get
 		{
-			ComputeLineSeparators();
+			ComputeLineStarts();
 
-			return lineSeparators.Count;
+			return lineStarts.Count;
 		}
 	}
 
@@ -90,81 +90,136 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 	/// <remarks>This method is not CLS-compliant due to the unsafe context and the use of pointers.</remarks>
 	[CLSCompliant(false)]
 	public unsafe ReadOnlyStringBuffer(byte* contentPtr, int byteCount, Encoding? encoding = null) =>
-		data = encoding?.GetString(contentPtr, byteCount) ?? Encoding.Default.GetString(contentPtr, byteCount);
+		data = (encoding ?? Encoding.Default).GetString(contentPtr, byteCount);
 
-	private int GetLineSeparatorAfter(int index, out int lsListIndex)
+	private int GetNextLineStartPosition(int index, out int lsListIndex) =>
+		// we use index + 1 to skip to the next line start if we're already standing on one :)
+		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index + 1), out lsListIndex);
+
+	/// <summary>
+	/// Shared code context for <see cref="GetNextLineStartPosition(Int32, out Int32)"/> and
+	/// <see cref="GetNextOrCurrentLineStartPosition(Int32, out Int32)"/>.
+	/// </summary>
+	/// <param name="insertionPoint">The insertion point of the next line start.</param>
+	/// <param name="lsListIndex">The index, in <see cref="lineStarts"/> where the line start is.</param>
+	/// <returns>The line start index, in <see cref="data"/>.</returns>
+	private int GetNextLineStartFromInsertionPoint(int insertionPoint, out int lsListIndex)
 	{
-		int insertionPoint = lineSeparators.BinarySearch(index);
-
-		lsListIndex = insertionPoint;
-
 		if (insertionPoint >= 0)
-			return lineSeparators[insertionPoint];
+		{
+			// 1st Case: the used index (might have been index + 1 based on the method that called this)
+			// points to an actual line start
+			lsListIndex = insertionPoint;
+			return lineStarts[insertionPoint];
+		}
 
-		lsListIndex = -1;
+		int nextIndex = ~insertionPoint;
 
-		if (~insertionPoint == lineSeparators.Count)
-			return data.Length - 1; // last character
+		if (nextIndex == lineStarts.Count)
+		{
+			// 2nd Case: the next line start is outside of the buffer (EOF convention)
+			lsListIndex = -1;
+			return data.Length;
+		}
 
-		lsListIndex = ~insertionPoint;
+		lsListIndex = nextIndex;
 
-		return lineSeparators[~insertionPoint];
+		return lineStarts[nextIndex]; // 3rd Case: we found the next line start
 	}
 
-	private int GetLineSeparatorBefore(int index, out int lsListIndex)
+	private int GetNextOrCurrentLineStartPosition(int index, out int lsListIndex) =>
+		// we use the actual index because we might already be standing on the line start
+		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
+
+	/// <summary>
+	/// Shared code context for <see cref="GetPreviousLineStartPosition(Int32, out Int32)"/> and
+	/// <see cref="GetPreviousOrCurrentLineStartPosition(Int32, out Int32)"/>.
+	/// </summary>
+	/// <param name="insertionPoint">The insertion point of the next line start.</param>
+	/// <param name="lsListIndex">The index, in <see cref="lineStarts"/> where the line start is.</param>
+	/// <returns>The line start index, in <see cref="data"/>.</returns>
+	private int GetPreviousLineStartFromInsertionPoint(int insertionPoint, out int lsListIndex)
 	{
-		lsListIndex = -1;
-
-		if (index == 0)
-			return 0;
-
-		int insertionPoint = lineSeparators.BinarySearch(index);
-
-		lsListIndex = insertionPoint;
-
 		if (insertionPoint >= 0)
-			return lineSeparators[lsListIndex];
+		{
+			// 1st Case: the used index (might have been index + 1 based on the method that called this)
+			// points to an actual line start
+			lsListIndex = insertionPoint;
+			return lineStarts[insertionPoint];
+		}
 
-		lsListIndex = lineSeparators.Count - 1;
+		int nextIndex = ~insertionPoint;
 
-		if (~insertionPoint == lineSeparators.Count)
-			return lineSeparators[lsListIndex];
+		if (nextIndex == lineStarts.Count)
+		{
+			// 2nd Case: the next line start is outside of the buffer (EOF convention)
+			lsListIndex = -1;
+			return data.Length;
+		}
 
-		lsListIndex = ~insertionPoint - 1;
+		lsListIndex = nextIndex < 0 ? 0 : nextIndex - 1;
 
-		if (lsListIndex == -1)
-			return 0;
-
-		return lineSeparators[lsListIndex];
+		return lineStarts[lsListIndex]; // 3rd Case: we found the previous line start
 	}
 
-	private void ComputeLineSeparators(bool forceCache = false)
+	private int GetPreviousLineStartPosition(int index, out int lsListIndex)
+	{
+		if (index > 0)
+		{
+			// when the index is greater than 0, we can safely get the previous line start without getting a big shitty error
+			// we use 0 as the start following standard conventions
+			return GetPreviousLineStartFromInsertionPoint(lineStarts.BinarySearch(index - 1), out lsListIndex);
+		}
+
+		lsListIndex = 0;
+		return 0;
+	}
+
+	private int GetPreviousOrCurrentLineStartPosition(int index, out int lsListIndex)
+	{
+		if (index > 0)
+		{
+			// when the index is greater than 0, we can safely get the previous line start without getting a big shitty error
+			// we use 0 as the start following standard conventions
+			return GetPreviousLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
+		}
+
+		lsListIndex = 0;
+		return 0;
+	}
+
+	private void ComputeLineStarts(bool forceCache = false)
 	{
 		if (CacheExists && !forceCache)
 			return;
 
 		var span = data.AsSpan();
 
-		lineSeparators.Clear();
-		crFollowedByLf.Clear();
+		lineStarts.Clear();
+		precededByCrLf.Clear();
 
-		lineSeparators.Capacity = Math.Max(lineSeparators.Capacity, span.Length / 25 + 32); // just a rough guess
-		crFollowedByLf.Capacity = Math.Max(crFollowedByLf.Capacity, span.Length / 25 + 16); // just a rough guess
+		lineStarts.Capacity = Math.Max(lineStarts.Capacity, span.Length / 25 + 32); // just a rough guess
+		precededByCrLf.Capacity = Math.Max(precededByCrLf.Capacity, span.Length / 25 + 16); // just a rough guess
 
 		int lastIndex = span.Length - 1;
+		int i = 0;
 
-		for (int i = 0; i < span.Length; i++)
+		while (i < span.Length)
 		{
 			if (!span[i].IsNewline())
-				continue; // immediate continue brotato
-
-			lineSeparators.Add(i);
-
-			if (i < lastIndex && span[i] == '\r' && span[i + 1] == '\n')
 			{
-				crFollowedByLf.Add(i);
-				i++; // skip the fucking LF associated to the CRLF
+				i++;
+				continue;
 			}
+
+			bool isCrLf = i < lastIndex && span[i] == '\r' && span[i + 1] == '\n';
+			int nextStart = i + (isCrLf ? 2 : 1);
+			lineStarts.Add(nextStart);
+
+			if (isCrLf)
+				precededByCrLf.Add(nextStart);
+
+			i = nextStart;
 		}
 
 		CacheExists = true;
@@ -236,10 +291,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (data[index].IsNewline())
 			return 0;
 
-		ComputeLineSeparators();
-		int lineSep = GetLineSeparatorAfter(index, out _);
+		ComputeLineStarts();
+		int lineSep = GetNextLineStartPosition(index, out _);
 
-		isCrLf = crFollowedByLf.Contains(lineSep);
+		isCrLf = precededByCrLf.Contains(lineSep);
 
 		return lineSep - index;
 	}
@@ -252,9 +307,9 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		ComputeLineSeparators();
+		ComputeLineStarts();
 
-		return index - GetLineSeparatorBefore(index, out _);
+		return index - GetPreviousLineStartPosition(index, out _);
 	}
 
 	private bool IsOutOfBounds(int index) => index >= data.Length;
@@ -299,8 +354,6 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		return true;
 	}
 
-	private bool IsStartOfLine(int index) => index == 0 || data[index - 1].IsNewline();
-
 	/// <inheritdoc/>
 	public bool TryGetNextLineFrom(int index, Span<char> line, out int itemCount)
 	{
@@ -315,9 +368,9 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (IsOutOfBounds(index))
 			return false;
 
-		ComputeLineSeparators();
+		ComputeLineStarts();
 
-		if (crFollowedByLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
+		if (precededByCrLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
 			index--;                            // use the CR in the CRLF sequence instead of using the LF
 
 		index += CountUntilLineSeparator(index, out bool isCrLf); // skip to the next line separator
@@ -483,7 +536,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 			return true;
 		}
 
-		ComputeLineSeparators();
+		ComputeLineStarts();
 
 		location = new(index, CountLinesBefore(index), ReverseCountUntilNewline(index));
 
@@ -495,7 +548,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (index == data.Length - 1)
 			return LineCount;
 
-		GetLineSeparatorBefore(index, out int lineSepIndex);
+		GetPreviousOrCurrentLineStartPosition(index, out int lineSepIndex);
 
 		return lineSepIndex + 1; // the amount of lines is the amount of line separators plus 1 ALWAYS
 	}
@@ -508,23 +561,23 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (IsEmpty || lineNumber < 0)
 			return false;
 
-		ComputeLineSeparators();
+		ComputeLineStarts();
 
-		if (lineNumber >= lineSeparators.Count)
+		if (lineNumber >= lineStarts.Count)
 			return false;
 
-		int spanEnd = lineSeparators[lineNumber];
+		int spanEnd = lineStarts[lineNumber];
 
 		int spanStartIndex = lineNumber == 0
 								 ? 0
 								 : lineNumber - 1;
 
-		if (crFollowedByLf.Contains(lineSeparators[spanStartIndex]))
+		if (precededByCrLf.Contains(lineStarts[spanStartIndex]))
 			spanStartIndex++; // skip past the CR in the CRLF sequence
 
 		spanStartIndex++; // get the actual start of the next line instead of the line sep
 
-		int spanStart = lineSeparators[spanStartIndex];
+		int spanStart = lineStarts[spanStartIndex];
 		int actualLineLength = spanEnd - spanStart + 1;
 		itemCount = Math.Min(actualLineLength, destination.Length);
 
@@ -547,20 +600,20 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (IsOutOfBounds(index))
 			return false;
 
-		ComputeLineSeparators();
+		ComputeLineStarts();
 
-		int spanStart = GetLineSeparatorBefore(index, out int lineSepBeforeIndex);
+		int spanStart = GetPreviousLineStartPosition(index, out int lineSepBeforeIndex);
 
 		if (lineSepBeforeIndex != -1) // only skip necessary characters if the start of the span isn't 0
 		{
-			if (crFollowedByLf.Contains(spanStart))
+			if (precededByCrLf.Contains(spanStart))
 				spanStart++; // skip the LF in the CRLF sequence (if applicable)
 
 			if (index < data.Length - 1)
 				spanStart++; // skip to the actual start of the line (but don't error out doing so)
 		}
 
-		int spanEnd = GetLineSeparatorAfter(index, out _);
+		int spanEnd = GetNextLineStartPosition(index, out _);
 
 		if (spanEnd > 0)
 			spanEnd--; // don't include the line separator
@@ -587,13 +640,13 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 
 	public int GetLengthOfLine(int lineNumber)
 	{
-		// todo: this should return the minimum length of a line (#54)
+		// todo: this should return the exact length of a line (#54)
 		throw new NotImplementedException();
 	}
 
 	public int GetLengthOfLineAt(int index)
 	{
-		// todo: this should return the minimum length of a line (#54)
+		// todo: this should return the exact length of a line (#54)
 		throw new NotImplementedException();
 	}
 
@@ -607,8 +660,61 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 	}
 
 	/// <inheritdoc/>
-	public void BuildCache() => ComputeLineSeparators();
+	public void BuildCache() => ComputeLineStarts();
 
 	/// <inheritdoc/>
-	public void BuildCache(bool forceRebuild) => ComputeLineSeparators(forceRebuild);
+	public void BuildCache(bool forceRebuild) => ComputeLineStarts(forceRebuild);
+
+	/// <inheritdoc/>
+#if NET10_0_OR_GREATER
+	public override bool Equals([NotNullWhen(true)] object? obj) =>
+#elif NETSTANDARD2_0
+	public override bool Equals(object obj) =>
+#endif
+		Equals(obj as ReadOnlyStringBuffer);
+
+	/// <summary>
+	/// Returns the buffer's content as a <see cref="String"/>.
+	/// </summary>
+	/// <returns>The buffer's content.</returns>
+	public override string ToString() => data;
+
+	/// <summary>
+	/// Checks if another read-only string buffer is equal to the current instance.
+	/// </summary>
+	/// <param name="other">The other read-only string buffer.</param>
+	/// <returns>True if equals.</returns>
+	public bool Equals(ReadOnlyStringBuffer? other) => other is not null && data == other.data && Length == other.Length && IsEmpty == other.IsEmpty && LineCount == other.LineCount;
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + EqualityComparer<string>.Default.GetHashCode(data);
+			hashCode = hashCode * InternalUtils.HashCodeMultiplier + Length.GetHashCode();
+			hashCode = hashCode * InternalUtils.HashCodeMultiplier + IsEmpty.GetHashCode();
+			return hashCode * InternalUtils.HashCodeMultiplier + LineCount.GetHashCode();
+		}
+	}
+
+	/// <summary>
+	/// Checks if another read-only buffer is equal to the current instance.
+	/// </summary>
+	/// <param name="other">The other read-only buffer.</param>
+	/// <returns>True if equals.</returns>
+	public bool Equals(IReadOnlyBuffer<char>? other) => other is ReadOnlyStringBuffer buffer && Equals(buffer);
+
+	/// <summary>
+	/// Checks if two read-only string buffers are equals.
+	/// </summary>
+	/// <returns>True if equals.</returns>
+	public static bool operator ==(ReadOnlyStringBuffer left, ReadOnlyStringBuffer right) =>
+		EqualityComparer<ReadOnlyStringBuffer>.Default.Equals(left, right);
+
+	/// <summary>
+	/// Checks if two read-only string buffers are different.
+	/// </summary>
+	/// <returns>True if different.</returns>
+	public static bool operator !=(ReadOnlyStringBuffer left, ReadOnlyStringBuffer right) => !(left == right);
 }

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -324,7 +324,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	}
 
 	/// <inheritdoc/>
-	public bool TryGetLineAt(int index, Span<char> line, out int itemCount)
+	public bool TryGetLineFromIndex(int index, Span<char> line, out int itemCount)
 	{
 		itemCount = 0;
 
@@ -356,7 +356,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	}
 
 	/// <inheritdoc/>
-	public bool TryGetNextLineFrom(int index, Span<char> line, out int itemCount)
+	public bool TryGetLineAfterIndex(int index, Span<char> line, out int itemCount)
 	{
 		itemCount = 0;
 
@@ -391,7 +391,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	}
 
 	/// <inheritdoc/>
-	public bool TryGetNextLineFrom(int index, Span<char> line, bool skipEmptyLines, out int itemCount)
+	public bool TryGetLineAfterIndex(int index, Span<char> line, bool skipEmptyLines, out int itemCount)
 	{
 		// todo: this should return the next line (see TryGetNextLineFrom(int, Span<char>, int))
 		// but skip empty lines if skipEmptyLines = true

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -249,6 +249,9 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (IsConventionallyOutOfRange(index))
 			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
 
+		if (index == Length)
+			return LineCount;
+
 		GetPreviousOrCurrentLineStartPosition(index, out int lineSepIndex);
 		return lineSepIndex;
 	}
@@ -331,30 +334,20 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (index < 0)
 			index += Length;
 
-		if (IsOutOfRange(index))
+		if (IsConventionallyOutOfRange(index))
 			return false;
 
+		if (index == Length) // EOF means the current line is empty (line is empty by default)
+			return true;
+
 		ComputeLineStarts();
-		int spanStart = GetPreviousLineStartPosition(index, out int lineSepBeforeIndex);
+		int spanStart = GetPreviousOrCurrentLineStartPosition(index, out _);
+		int spanEnd = GetNextLineStartPosition(index, out int nextLineStartIndex) - 1; // don't include the line separator
 
-		if (lineSepBeforeIndex != -1) // only skip necessary characters if the start of the span isn't 0
-		{
-			if (precededByCrLf.Contains(spanStart))
-				spanStart++; // skip the LF in the CRLF sequence (if applicable)
+		if (precededByCrLf.Contains(nextLineStartIndex))
+			spanEnd--; // remove one extra line separator if it's CRLF
 
-			if (index < data.Length - 1)
-				spanStart++; // skip to the actual start of the line (but don't error out doing so)
-		}
-
-		int spanEnd = GetNextLineStartPosition(index, out _);
-
-		if (spanEnd > 0)
-			spanEnd--; // don't include the line separator
-
-		if (spanStart > spanEnd)
-			spanStart = spanEnd; // empty span
-
-		int actualLineLength = spanEnd - spanStart + 1;
+		int actualLineLength = spanEnd - spanStart;
 		itemCount = Math.Min(actualLineLength, line.Length);
 
 		data.AsSpan(spanStart, itemCount).CopyTo(line);
@@ -714,8 +707,10 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (previousIndex == lineStarts.Count)
 		{
 			// 2nd Case: the next line start is outside of the buffer (EOF convention)
-			lsListIndex = previousIndex;
-			return data.Length;
+			// however we're gonna decrement one because otherwise all indexes from the last line that are after
+			// start of said line suddenly become part of the EOF line
+			lsListIndex = previousIndex - 1;
+			return Length;
 		}
 
 		lsListIndex = previousIndex == 0 ? 0 : previousIndex - 1;

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -142,7 +142,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		if (IsConventionallyOutOfRange(index))
 			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
@@ -172,7 +172,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		if (IsConventionallyOutOfRange(index))
 			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
@@ -202,7 +202,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		if (IsConventionallyOutOfRange(index))
 			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
@@ -238,13 +238,13 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	/// <paramref name="index"/> was set to something greater than the buffer's length.
 	/// </exception>
 	/// <inheritdoc/>
-	public int GetLineNumberAt(int index)
+	public int GetLineNumberForIndex(int index)
 	{
 		if (IsEmpty)
 			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsConventionallyOutOfRange(index))
 			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
@@ -277,7 +277,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		if (IsOutOfRange(index))
 			return false;
@@ -329,7 +329,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsOutOfRange(index))
 			return false;
@@ -371,7 +371,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsOutOfRange(index))
 			return false;
@@ -418,7 +418,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsOutOfRange(index))
 			return false;
@@ -432,7 +432,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 
 		ComputeLineStarts();
 
-		location = new(index, GetLineNumberAt(index), ReverseCountUntilNewline(index));
+		location = new(index, GetLineNumberForIndex(index), ReverseCountUntilNewline(index));
 
 		return true;
 	}
@@ -447,7 +447,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsOutOfRange(index))
 			return false;
@@ -478,7 +478,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsOutOfRange(index))
 			return false;
@@ -509,7 +509,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return false;
 
 		if (index < 0)
-			index += data.Length;
+			index += Length;
 
 		if (IsOutOfRange(index))
 			return false;
@@ -629,7 +629,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	private int CountUntilMatch(int index, char character)
 	{
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		var span = data.AsSpan(index);
 		int count = 0;
@@ -643,7 +643,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	private int CountUntilNotMatch(int index, char character)
 	{
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		var span = data.AsSpan(index);
 		int count = 0;
@@ -677,7 +677,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		{
 			// 2nd Case: the next line start is outside of the buffer (EOF convention)
 			lsListIndex = -1;
-			return data.Length;
+			return Length;
 		}
 
 		lsListIndex = nextIndex;
@@ -756,14 +756,14 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	/// Does not protect against <see cref="ArgumentOutOfRangeException"/> and
 	/// <see cref="IndexOutOfRangeException"/>.
 	/// </summary>
-	private bool IsConventionallyOutOfRange(int index) => index > data.Length;
+	private bool IsConventionallyOutOfRange(int index) => index > Length;
 
 	/// <summary>
 	/// True if index is greater than or equal to the length.
 	/// This prevents throwing <see cref="ArgumentOutOfRangeException"/>
 	/// or <see cref="IndexOutOfRangeException"/>.
 	/// </summary>
-	private bool IsOutOfRange(int index) => index >= data.Length;
+	private bool IsOutOfRange(int index) => index >= Length;
 
 	/// <remarks>
 	/// Ignores the LF in CRLF sequences (returns the CR if the matching sequence is CRLF) - avoid double counting and other issues.
@@ -771,7 +771,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	private int ReverseCountUntilNewline(int index)
 	{
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
 		ComputeLineStarts();
 

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -10,7 +10,7 @@ namespace OceanApocalypseStudios.RSML.Sources.Buffers;
 
 /// <summary>
 /// A read-only buffer backed by a string. All operations opt for performance
-/// primarily via the internal use of <see cref="Span{Char}"/> over string allocations
+/// primarily via the internal use of <see cref="ReadOnlySpan{Char}"/> over string allocations
 /// and also via caching.
 /// </summary>
 public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEquatable<ReadOnlyStringBuffer?>
@@ -98,42 +98,57 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	/// <inheritdoc/>
 	public void BuildCache(bool forceRebuild) => ComputeLineStarts(forceRebuild);
 
+	/// <exception cref="BufferException">
+	/// The buffer is empty.
+	/// </exception>
+	/// <exception cref="IndexOutOfRangeException">
+	/// <paramref name="index"/> was set to something greater than the buffer's length.
+	/// </exception>
 	/// <inheritdoc/>
 	public int CountUntilLineSeparator(int index, out bool isCrLf)
 	{
 		isCrLf = false;
 
 		if (IsEmpty)
-			return 0;
+			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
-			index = data.Length + index; // -1 is (Length-1) etc
+			index = Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfRange(index))
-			return -1;
+		if (IsConventionallyOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
 
-		if (data[index].IsNewline())
-			return 0;
+		if (index == Length)
+			return 0; // consumed the entire buffer
 
 		ComputeLineStarts();
-		int lineSep = GetNextLineStartPosition(index, out _);
+		int lineSep = GetNextOrCurrentLineStartPosition(index, out _);
 
 		isCrLf = precededByCrLf.Contains(lineSep);
 
 		return lineSep - index;
 	}
 
+	/// <exception cref="BufferException">
+	/// The buffer is empty.
+	/// </exception>
+	/// <exception cref="IndexOutOfRangeException">
+	/// <paramref name="index"/> was set to something greater than the buffer's length.
+	/// </exception>
 	/// <inheritdoc/>
 	public int CountUntilNotWhitespace(int index)
 	{
 		if (IsEmpty)
-			return 0;
+			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfRange(index))
-			return -1;
+		if (IsConventionallyOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
+		
+		if (index == Length)
+			return 0; // consumed the entire buffer
 
 		var span = data.AsSpan(index);
 		int count = 0;
@@ -144,17 +159,26 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		return count;
 	}
 
+	/// <exception cref="BufferException">
+	/// The buffer is empty.
+	/// </exception>
+	/// <exception cref="IndexOutOfRangeException">
+	/// <paramref name="index"/> was set to something greater than the buffer's length.
+	/// </exception>
 	/// <inheritdoc/>
 	public int CountUntilWhitespace(int index)
 	{
 		if (IsEmpty)
-			return 0;
+			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfRange(index))
-			return -1;
+		if (IsConventionallyOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
+
+		if (index == Length)
+			return 0; // consumed the entire buffer
 
 		var span = data.AsSpan(index);
 		int count = 0;
@@ -165,17 +189,26 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		return count;
 	}
 
+	/// <exception cref="BufferException">
+	/// The buffer is empty.
+	/// </exception>
+	/// <exception cref="IndexOutOfRangeException">
+	/// <paramref name="index"/> was set to something greater than the buffer's length.
+	/// </exception>
 	/// <inheritdoc/>
 	public int CountWhile(Func<int, char, bool> predicate, int index)
 	{
 		if (IsEmpty)
-			return 0;
+			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
 			index = data.Length + index; // -1 is (Length-1) etc
 
-		if (IsOutOfRange(index))
-			return -1;
+		if (IsConventionallyOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
+
+		if (index == Length)
+			return 0; // consumed the entire buffer
 
 		var span = data.AsSpan(index);
 		int count = 0;
@@ -208,13 +241,13 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public int GetLineNumberAt(int index)
 	{
 		if (IsEmpty)
-			throw new BufferException("Buffer cannot be empty.");
+			throw new BufferException("The buffer is empty.");
 
 		if (index < 0)
 			index += data.Length;
 
 		if (IsConventionallyOutOfRange(index))
-			throw new IndexOutOfRangeException("Index must be less than the buffer's length in this context.");
+			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
 
 		GetPreviousOrCurrentLineStartPosition(index, out int lineSepIndex);
 		return lineSepIndex;

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -5,615 +5,590 @@ using System.Text;
 using OceanApocalypseStudios.RSML.Common;
 
 
-namespace OceanApocalypseStudios.RSML.Sources.Buffers
+namespace OceanApocalypseStudios.RSML.Sources.Buffers;
+
+/// <summary>
+/// A read-only buffer backed by a string. All operations opt for performance
+/// primarily via the internal use of <see cref="Span{Char}"/> over string allocations
+/// and also via caching.
+/// </summary>
+public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
 {
+	readonly List<int> lineSeparators = [];
+	readonly List<int> crFollowedByLf = [];
+	readonly string data;
 
-	/// <summary>
-	/// A read-only buffer backed by a string. All operations opt for performance
-	/// primarily via the internal use of <see cref="Span{Char}"/> over string allocations
-	/// and also via caching.
-	/// </summary>
-	public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache
+	/// <inheritdoc/>
+	public int Length => data.Length;
+
+	/// <inheritdoc/>
+	public bool IsEmpty => Length == 0;
+
+	/// <inheritdoc/>
+	public int LineCount
 	{
-		readonly List<int> lineSeparators = [];
-		readonly List<int> crFollowedByLf = [];
-		readonly string data;
-
-		/// <inheritdoc/>
-		public int Length => data.Length;
-
-		/// <inheritdoc/>
-		public bool IsEmpty => Length == 0;
-
-		/// <inheritdoc/>
-		public int LineCount
+		get
 		{
-
-			get
-			{
-
-				ComputeLineSeparators();
-				return lineSeparators.Count;
-
-			}
-
-		}
-
-		/// <inheritdoc/>
-		public bool CacheExists { get; private set; } = false;
-
-		/// <inheritdoc/>
-		public char this[int index] => data[index];
-
-		/// <summary>
-		/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
-		/// with a string.
-		/// </summary>
-		/// <param name="content">The string that the buffer will wrap.</param>
-		public ReadOnlyStringBuffer(string content) => data = content;
-
-		/// <summary>
-		/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
-		/// by allocating a string from a <see cref="ReadOnlySpan{Char}"/>.
-		/// </summary>
-		/// <param name="content">The span pointing to the string's data.</param>
-		public ReadOnlyStringBuffer(ReadOnlySpan<char> content) => data = content.ToString();
-
-		/// <summary>
-		/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
-		/// with an array of characters.
-		/// </summary>
-		/// <param name="content">The array of characters to use for the buffer.</param>
-		public ReadOnlyStringBuffer(char[] content) => data = new(content);
-
-		/// <summary>
-		/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
-		/// with an array of bytes and the encoding to use when decoding them.
-		/// </summary>
-		/// <param name="content">The array of bytes to use for the buffer.</param>
-		/// <param name="encoding">
-		/// The encoding to use when decoding <paramref name="content"/>.
-		/// Use <c>null</c> for the <see cref="Encoding.Default"/> encoding.
-		/// </param>
-		public ReadOnlyStringBuffer(byte[] content, Encoding? encoding = null) => data = encoding?.GetString(content) ?? Encoding.Default.GetString(content);
-
-		/// <summary>
-		/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
-		/// with a pointer referencing an array of bytes and the encoding
-		/// to use when decoding them.
-		/// </summary>
-		/// <param name="contentPtr">The pointer referecing the array of bytes to use for the buffer.</param>
-		/// <param name="byteCount">The amount of bytes in the array referenced by <paramref name="contentPtr"/>.</param>
-		/// <param name="encoding">
-		/// The encoding to use when decoding <paramref name="contentPtr"/>.
-		/// Use <c>null</c> for the <see cref="Encoding.Default"/> encoding.
-		/// </param>
-		/// <remarks>This method is not CLS-compliant due to the unsafe context and the use of pointers.</remarks>
-		[CLSCompliant(false)]
-		public unsafe ReadOnlyStringBuffer(byte* contentPtr, int byteCount, Encoding? encoding = null) => data = encoding?.GetString(contentPtr, byteCount) ?? Encoding.Default.GetString(contentPtr, byteCount);
-
-		private int GetLineSeparatorAfter(int index, out int lsListIndex)
-		{
-
-			int insertionPoint = lineSeparators.BinarySearch(index);
-
-			lsListIndex = insertionPoint;
-
-			if (insertionPoint >= 0)
-				return lineSeparators[insertionPoint];
-
-			lsListIndex = -1;
-
-			if (~insertionPoint == lineSeparators.Count)
-				return data.Length - 1; // last character
-
-			lsListIndex = ~insertionPoint;
-
-			return lineSeparators[~insertionPoint];
-
-		}
-
-		private int GetLineSeparatorBefore(int index, out int lsListIndex)
-		{
-
-			lsListIndex = -1;
-
-			if (index == 0)
-				return 0;
-
-			int insertionPoint = lineSeparators.BinarySearch(index);
-
-			lsListIndex = insertionPoint;
-
-			if (insertionPoint >= 0)
-				return lineSeparators[lsListIndex];
-
-			lsListIndex = lineSeparators.Count - 1;
-
-			if (~insertionPoint == lineSeparators.Count)
-				return lineSeparators[lsListIndex];
-
-			lsListIndex = ~insertionPoint - 1;
-
-			if (lsListIndex == -1)
-				return lineSeparators[0];
-
-			return lineSeparators[lsListIndex];
-
-		}
-
-		private void ComputeLineSeparators(bool forceCache = false)
-		{
-
-			if (CacheExists && !forceCache)
-				return;
-
-			var span = data.AsSpan();
-
-			lineSeparators.Clear();
-			crFollowedByLf.Clear();
-
-			lineSeparators.Capacity = Math.Max(lineSeparators.Capacity, span.Length / 25 + 32); // just a rough guess
-			crFollowedByLf.Capacity = Math.Max(crFollowedByLf.Capacity, span.Length / 25 + 16); // just a rough guess
-
-			int lastIndex = span.Length - 1;
-
-			for (int i = 0; i < span.Length; i++)
-			{
-
-				if (!span[i].IsNewline())
-					continue; // immediate continue brotato
-
-				lineSeparators.Add(i);
-
-				if (i < lastIndex && span[i] == '\r' && span[i + 1] == '\n')
-				{
-
-					crFollowedByLf.Add(i);
-					i++; // skip the fucking LF associated to the CRLF
-
-				}
-
-			}
-
-			CacheExists = true;
-
-		}
-
-		/// <inheritdoc/>
-		public int CountUntilWhitespace(int index)
-		{
-
-			if (IsBufferEmpty())
-				return 0;
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			if (IsOutOfBounds(index))
-				return -1;
-
-			var span = data.AsSpan(index);
-			int count = 0;
-
-			while (count < span.Length && !Char.IsWhiteSpace(span[count]))
-				count++;
-
-			return count;
-
-		}
-
-		private int CountUntilMatch(int index, char character)
-		{
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			var span = data.AsSpan(index);
-			int count = 0;
-
-			while (count < span.Length && span[count] == character)
-				count++;
-
-			return count;
-
-		}
-
-		private int CountUntilNotMatch(int index, char character)
-		{
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			var span = data.AsSpan(index);
-			int count = 0;
-
-			while (count < span.Length && span[count] != character)
-				count++;
-
-			return count;
-
-		}
-
-		/// <inheritdoc/>
-		public int CountUntilLineSeparator(int index, out bool isCrLf)
-		{
-
-			isCrLf = false;
-
-			if (IsBufferEmpty())
-				return 0;
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			if (IsOutOfBounds(index))
-				return -1;
-
-			if (data[index].IsNewline())
-				return 0;
-
 			ComputeLineSeparators();
-			var lineSep = GetLineSeparatorAfter(index, out _);
-
-			isCrLf = crFollowedByLf.Contains(lineSep);
-
-			return lineSep - index;
-
+			return lineSeparators.Count;
 		}
-
-		/// <remarks>
-		/// Ignores the LF in CRLF sequences (returns the CR if the matching sequence is CRLF) - avoid double counting and other issues.
-		/// </remarks>
-		private int ReverseCountUntilNewline(int index)
-		{
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			ComputeLineSeparators();
-
-			return index - GetLineSeparatorBefore(index, out _);
-
-		}
-
-		private bool IsOutOfBounds(int index) => index >= data.Length;
-
-		private bool IsBufferEmpty() => data.Length == 0;
-
-		/// <inheritdoc/>
-		public int CountWhile(Func<int, char, bool> predicate, int index)
-		{
-
-			if (IsBufferEmpty())
-				return 0;
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			if (IsOutOfBounds(index))
-				return -1;
-
-			var span = data.AsSpan(index);
-			int count = 0;
-
-			while (count < span.Length && predicate(count, span[count]))
-				count++;
-
-			return count;
-
-		}
-
-		/// <inheritdoc/>
-		public bool TryGetChar(int index, out char item)
-		{
-
-			item = '\0'; // default
-
-			if (IsBufferEmpty())
-				return false;
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			item = data[index];
-			return true;
-
-		}
-
-		private bool IsStartOfLine(int index) => index == 0 || data[index - 1].IsNewline();
-
-		/// <inheritdoc/>
-		public bool TryGetNextLineFrom(int index, Span<char> line, out int itemCount)
-		{
-
-			itemCount = 0;
-
-			if (IsBufferEmpty())
-				return false;
-
-			if (index < 0)
-				index += data.Length;
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			ComputeLineSeparators();
-
-			if (crFollowedByLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
-				index--; // use the CR in the CRLF sequence instead of using the LF
-
-			index += CountUntilLineSeparator(index, out bool isCrLf); // skip to the next line separator
-			index += isCrLf ? 2 : 1; // skip to the actual start of the next line (skip twice if CRLF)
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			// when summed with the index, returns the line separator index - which must be excluded from the return value
-			var actualLineLength = CountUntilLineSeparator(index, out _);
-			var charsToCopyAmount = Math.Min(actualLineLength, line.Length);
-			data.AsSpan(index, charsToCopyAmount).CopyTo(line);
-
-			itemCount = charsToCopyAmount;
-
-			return line.Length >= actualLineLength;
-
-		}
-
-		/// <inheritdoc/>
-		public bool TryGetWord(int index, Span<char> destination, out bool isWhitespace, out int itemCount)
-		{
-
-			isWhitespace = false;
-			itemCount = 0;
-
-			if (IsBufferEmpty())
-				return false;
-
-			if (index < 0)
-				index += data.Length;
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			isWhitespace = Char.IsWhiteSpace(data[index]);
-
-			// if first index is whitespace, the word is whitespace (ends when not whitespace/end of buffer)
-			// if first index not whitespace, the word is not whitespace (ends on whitespace/end of buffer)
-			int actualLineLength = isWhitespace ? CountUntilNotWhitespace(index) : CountUntilWhitespace(index);
-			int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-			data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-			itemCount = charsToCopyAmount;
-
-			return destination.Length >= actualLineLength;
-
-		}
-
-		/// <inheritdoc/>
-		public bool TryGetWord(int index, char itemKind, Span<char> destination, out bool isItemKind, out int itemCount)
-		{
-
-			isItemKind = false;
-			itemCount = 0;
-
-			if (IsBufferEmpty())
-				return false;
-
-			if (index < 0)
-				index += data.Length;
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			isItemKind = data[index] == itemKind;
-
-			// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
-			// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-			int actualLineLength = isItemKind ? CountUntilNotMatch(index, itemKind) : CountUntilMatch(index, itemKind);
-			int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-			data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-			itemCount = charsToCopyAmount;
-
-			return destination.Length >= actualLineLength;
-
-		}
-
-		/// <inheritdoc/>
-		public int CountUntilNotWhitespace(int index)
-		{
-
-			if (IsBufferEmpty())
-				return 0;
-
-			if (index < 0)
-				index = data.Length + index; // -1 is (Length-1) etc
-
-			if (IsOutOfBounds(index))
-				return -1;
-
-			var span = data.AsSpan(index);
-			int count = 0;
-
-			while (count < span.Length && Char.IsWhiteSpace(span[count]))
-				count++;
-
-			return count;
-
-		}
-
-		/// <inheritdoc/>
-		public char[] Slice(int start, int length) => data.ToCharArray(start, length);
-
-		/// <inheritdoc/>
-		public void Dispose() => GC.SuppressFinalize(this);
-
-		/// <inheritdoc/>
-		public bool TryGetWord(int index, Func<int, char, bool> itemKindPredicate, Span<char> destination, out bool isItemKind, out int itemCount)
-		{
-
-			isItemKind = false;
-			itemCount = 0;
-
-			if (IsBufferEmpty())
-				return false;
-
-			if (index < 0)
-				index += data.Length;
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			isItemKind = itemKindPredicate(index, data[index]);
-
-			// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
-			// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-			int actualLineLength = isItemKind ? CountWhile((i, c) => !itemKindPredicate(i, c), index) : CountWhile(itemKindPredicate, index);
-			int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-			data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-			itemCount = charsToCopyAmount;
-
-			return destination.Length >= actualLineLength;
-
-		}
-
-		/// <inheritdoc/>
-		public void Slice(int start, Span<char> slice) => data.AsSpan(start, slice.Length).CopyTo(slice);
-
-		/// <remarks>
-		/// This implementation, unlike others, is official and does not suffer from major performance issues.
-		/// </remarks>
-		/// <inheritdoc/>
-		public bool TryGetSourceLocation(int index, out SourceLocation location)
-		{
-
-			location = new();
-
-			if (IsBufferEmpty())
-				return false;
-
-			if (index < 0)
-				index += data.Length;
-
-			if (IsOutOfBounds(index))
-				return false;
-
-			if (index == 0) // best "best" case = triple zero
-			{
-
-				location = new(0, 0, 0);
-				return true;
-
-			}
-
-			ComputeLineSeparators();
-
-			location = new(index, CountLinesBefore(index), ReverseCountUntilNewline(index));
-			return true;
-
-		}
-
-		internal int CountLinesBefore(int index)
-		{
-
-			if (index == data.Length - 1)
-				return LineCount;
-
-			GetLineSeparatorBefore(index, out int lineSepIndex);
-
-			return lineSepIndex + 1; // the amount of lines is the amount of line separators plus 1 ALWAYS
-
-		}
-
-		/// <inheritdoc/>
-		public bool TryGetLine(int lineNumber, Span<char> destination, out int itemCount)
-		{
-
-			itemCount = 0;
-
-			if (IsBufferEmpty() || lineNumber < 0)
-				return false;
-
-			ComputeLineSeparators();
-
-			if (lineNumber >= lineSeparators.Count)
-				return false;
-
-			var spanEnd = lineSeparators[lineNumber];
-			var spanStartIndex = lineNumber == 0 ? 0 : (lineNumber - 1);
-
-			if (crFollowedByLf.Contains(lineSeparators[spanStartIndex]))
-				spanStartIndex++; // skip past the CR in the CRLF sequence
-
-			spanStartIndex++; // get the actual start of the next line instead of the line sep
-
-			var spanStart = lineSeparators[spanStartIndex];
-			var actualLineLength = spanEnd - spanStart + 1;
-			itemCount = Math.Min(actualLineLength, destination.Length);
-
-			data.AsSpan(spanStart, itemCount).CopyTo(destination);
-
-			return actualLineLength > destination.Length;
-
-		}
-
-		/// <inheritdoc/>
-		public bool TryGetLineAt(int index, Span<char> line, out int itemCount)
-		{
-
-			// todo: this should return the line that contains the item at index (#55)
-			throw new NotImplementedException();
-
-		}
-
-		/// <inheritdoc/>
-		public void Slice(SourceSpan sourceSpan, Span<char> slice)
-		{
-
-			if (slice.Length < sourceSpan.Length)
-				throw new ArgumentException("The slice's length is less than the span's length and therefore cannot contain the sliced region.", nameof(slice));
-
-			data.AsSpan(sourceSpan.Start.Index, sourceSpan.Length).CopyTo(slice);
-
-		}
-
-		public int GetLengthOfLine(int lineNumber)
-		{
-
-			// todo: this should return the minimum length of a line (#54)
-			throw new NotImplementedException();
-
-		}
-
-		public int GetLengthOfLineAt(int index)
-		{
-
-			// todo: this should return the minimum length of a line (#54)
-			throw new NotImplementedException();
-
-		}
-
-		public bool TryGetNextLineFrom(int index, Span<char> line, bool skipEmptyLines, out int itemCount)
-		{
-
-			// todo: this should return the next line (see TryGetNextLineFrom(int, Span<char>, int))
-			// but skip empty lines if skipEmptyLines = true
-			// see #52
-			throw new NotImplementedException();
-
-		}
-
-		/// <inheritdoc/>
-		public void BuildCache() => ComputeLineSeparators();
-
-		/// <inheritdoc/>
-		public void BuildCache(bool forceRebuild) => ComputeLineSeparators(forceRebuild);
-
 	}
 
+	/// <inheritdoc/>
+	public bool CacheExists { get; private set; } = false;
+
+	/// <inheritdoc/>
+	public char this[int index] => data[index];
+
+	/// <summary>
+	/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
+	/// with a string.
+	/// </summary>
+	/// <param name="content">The string that the buffer will wrap.</param>
+	public ReadOnlyStringBuffer(string content) => data = content;
+
+	/// <summary>
+	/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
+	/// by allocating a string from a <see cref="ReadOnlySpan{Char}"/>.
+	/// </summary>
+	/// <param name="content">The span pointing to the string's data.</param>
+	public ReadOnlyStringBuffer(ReadOnlySpan<char> content) => data = content.ToString();
+
+	/// <summary>
+	/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
+	/// with an array of characters.
+	/// </summary>
+	/// <param name="content">The array of characters to use for the buffer.</param>
+	public ReadOnlyStringBuffer(char[] content) => data = new(content);
+
+	/// <summary>
+	/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
+	/// with an array of bytes and the encoding to use when decoding them.
+	/// </summary>
+	/// <param name="content">The array of bytes to use for the buffer.</param>
+	/// <param name="encoding">
+	/// The encoding to use when decoding <paramref name="content"/>.
+	/// Use <c>null</c> for the <see cref="Encoding.Default"/> encoding.
+	/// </param>
+	public ReadOnlyStringBuffer(byte[] content, Encoding? encoding = null) => data = encoding?.GetString(content) ?? Encoding.Default.GetString(content);
+
+	/// <summary>
+	/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
+	/// with a pointer referencing an array of bytes and the encoding
+	/// to use when decoding them.
+	/// </summary>
+	/// <param name="contentPtr">The pointer referecing the array of bytes to use for the buffer.</param>
+	/// <param name="byteCount">The amount of bytes in the array referenced by <paramref name="contentPtr"/>.</param>
+	/// <param name="encoding">
+	/// The encoding to use when decoding <paramref name="contentPtr"/>.
+	/// Use <c>null</c> for the <see cref="Encoding.Default"/> encoding.
+	/// </param>
+	/// <remarks>This method is not CLS-compliant due to the unsafe context and the use of pointers.</remarks>
+	[CLSCompliant(false)]
+	public unsafe ReadOnlyStringBuffer(byte* contentPtr, int byteCount, Encoding? encoding = null) => data = encoding?.GetString(contentPtr, byteCount) ?? Encoding.Default.GetString(contentPtr, byteCount);
+
+	private int GetLineSeparatorAfter(int index, out int lsListIndex)
+	{
+		int insertionPoint = lineSeparators.BinarySearch(index);
+
+		lsListIndex = insertionPoint;
+
+		if (insertionPoint >= 0)
+			return lineSeparators[insertionPoint];
+
+		lsListIndex = -1;
+
+		if (~insertionPoint == lineSeparators.Count)
+			return data.Length - 1; // last character
+
+		lsListIndex = ~insertionPoint;
+
+		return lineSeparators[~insertionPoint];
+	}
+
+	private int GetLineSeparatorBefore(int index, out int lsListIndex)
+	{
+		lsListIndex = -1;
+
+		if (index == 0)
+			return 0;
+
+		int insertionPoint = lineSeparators.BinarySearch(index);
+
+		lsListIndex = insertionPoint;
+
+		if (insertionPoint >= 0)
+			return lineSeparators[lsListIndex];
+
+		lsListIndex = lineSeparators.Count - 1;
+
+		if (~insertionPoint == lineSeparators.Count)
+			return lineSeparators[lsListIndex];
+
+		lsListIndex = ~insertionPoint - 1;
+
+		if (lsListIndex == -1)
+			return 0;
+
+		return lineSeparators[lsListIndex];
+	}
+
+	private void ComputeLineSeparators(bool forceCache = false)
+	{
+		if (CacheExists && !forceCache)
+			return;
+
+		var span = data.AsSpan();
+
+		lineSeparators.Clear();
+		crFollowedByLf.Clear();
+
+		lineSeparators.Capacity = Math.Max(lineSeparators.Capacity, span.Length / 25 + 32); // just a rough guess
+		crFollowedByLf.Capacity = Math.Max(crFollowedByLf.Capacity, span.Length / 25 + 16); // just a rough guess
+
+		int lastIndex = span.Length - 1;
+
+		for (int i = 0; i < span.Length; i++)
+		{
+			if (!span[i].IsNewline())
+				continue; // immediate continue brotato
+
+			lineSeparators.Add(i);
+
+			if (i < lastIndex && span[i] == '\r' && span[i + 1] == '\n')
+			{
+				crFollowedByLf.Add(i);
+				i++; // skip the fucking LF associated to the CRLF
+			}
+		}
+
+		CacheExists = true;
+	}
+
+	/// <inheritdoc/>
+	public int CountUntilWhitespace(int index)
+	{
+		if (IsEmpty)
+			return 0;
+
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		if (IsOutOfBounds(index))
+			return -1;
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && !Char.IsWhiteSpace(span[count]))
+			count++;
+
+		return count;
+	}
+
+	private int CountUntilMatch(int index, char character)
+	{
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && span[count] == character)
+			count++;
+
+		return count;
+	}
+
+	private int CountUntilNotMatch(int index, char character)
+	{
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && span[count] != character)
+			count++;
+
+		return count;
+	}
+
+	/// <inheritdoc/>
+	public int CountUntilLineSeparator(int index, out bool isCrLf)
+	{
+		isCrLf = false;
+
+		if (IsEmpty)
+			return 0;
+
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		if (IsOutOfBounds(index))
+			return -1;
+
+		if (data[index].IsNewline())
+			return 0;
+
+		ComputeLineSeparators();
+		var lineSep = GetLineSeparatorAfter(index, out _);
+
+		isCrLf = crFollowedByLf.Contains(lineSep);
+
+		return lineSep - index;
+	}
+
+	/// <remarks>
+	/// Ignores the LF in CRLF sequences (returns the CR if the matching sequence is CRLF) - avoid double counting and other issues.
+	/// </remarks>
+	private int ReverseCountUntilNewline(int index)
+	{
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		ComputeLineSeparators();
+
+		return index - GetLineSeparatorBefore(index, out _);
+	}
+
+	private bool IsOutOfBounds(int index) => index >= data.Length;
+
+	/// <inheritdoc/>
+	public int CountWhile(Func<int, char, bool> predicate, int index)
+	{
+		if (IsEmpty)
+			return 0;
+
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		if (IsOutOfBounds(index))
+			return -1;
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && predicate(count, span[count]))
+			count++;
+
+		return count;
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetChar(int index, out char item)
+	{
+		item = '\0'; // default
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		item = data[index];
+		return true;
+	}
+
+	private bool IsStartOfLine(int index) => index == 0 || data[index - 1].IsNewline();
+
+	/// <inheritdoc/>
+	public bool TryGetNextLineFrom(int index, Span<char> line, out int itemCount)
+	{
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		ComputeLineSeparators();
+
+		if (crFollowedByLf.Contains(index - 1)) // is the current index pointing to a LF inside a CRLF?
+			index--; // use the CR in the CRLF sequence instead of using the LF
+
+		index += CountUntilLineSeparator(index, out bool isCrLf); // skip to the next line separator
+		index += isCrLf ? 2 : 1; // skip to the actual start of the next line (skip twice if CRLF)
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		// when summed with the index, returns the line separator index - which must be excluded from the return value
+		var actualLineLength = CountUntilLineSeparator(index, out _);
+		var charsToCopyAmount = Math.Min(actualLineLength, line.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(line);
+
+		itemCount = charsToCopyAmount;
+
+		return line.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetWord(int index, Span<char> destination, out bool isWhitespace, out int itemCount)
+	{
+		isWhitespace = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		isWhitespace = Char.IsWhiteSpace(data[index]);
+
+		// if first index is whitespace, the word is whitespace (ends when not whitespace/end of buffer)
+		// if first index not whitespace, the word is not whitespace (ends on whitespace/end of buffer)
+		int actualLineLength = isWhitespace ? CountUntilNotWhitespace(index) : CountUntilWhitespace(index);
+		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
+
+		itemCount = charsToCopyAmount;
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetWord(int index, char itemKind, Span<char> destination, out bool isItemKind, out int itemCount)
+	{
+		isItemKind = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		isItemKind = data[index] == itemKind;
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int actualLineLength = isItemKind ? CountUntilNotMatch(index, itemKind) : CountUntilMatch(index, itemKind);
+		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
+
+		itemCount = charsToCopyAmount;
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public int CountUntilNotWhitespace(int index)
+	{
+		if (IsEmpty)
+			return 0;
+
+		if (index < 0)
+			index = data.Length + index; // -1 is (Length-1) etc
+
+		if (IsOutOfBounds(index))
+			return -1;
+
+		var span = data.AsSpan(index);
+		int count = 0;
+
+		while (count < span.Length && Char.IsWhiteSpace(span[count]))
+			count++;
+
+		return count;
+	}
+
+	/// <inheritdoc/>
+	public char[] Slice(int start, int length) => data.ToCharArray(start, length);
+
+	/// <inheritdoc/>
+	public void Dispose() => GC.SuppressFinalize(this);
+
+	/// <inheritdoc/>
+	public bool TryGetWord(int index, Func<int, char, bool> itemKindPredicate, Span<char> destination, out bool isItemKind, out int itemCount)
+	{
+		isItemKind = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		isItemKind = itemKindPredicate(index, data[index]);
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int actualLineLength = isItemKind ? CountWhile((i, c) => !itemKindPredicate(i, c), index) : CountWhile(itemKindPredicate, index);
+		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
+
+		itemCount = charsToCopyAmount;
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <inheritdoc/>
+	public void Slice(int start, Span<char> slice) => data.AsSpan(start, slice.Length).CopyTo(slice);
+
+	/// <remarks>
+	/// This implementation, unlike others, is official and does not suffer from major performance issues.
+	/// </remarks>
+	/// <inheritdoc/>
+	public bool TryGetSourceLocation(int index, out SourceLocation location)
+	{
+		location = new();
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		if (index == 0) // best "best" case = triple zero
+		{
+			location = new(0, 0, 0);
+			return true;
+		}
+
+		ComputeLineSeparators();
+
+		location = new(index, CountLinesBefore(index), ReverseCountUntilNewline(index));
+		return true;
+	}
+
+	internal int CountLinesBefore(int index)
+	{
+		if (index == data.Length - 1)
+			return LineCount;
+
+		GetLineSeparatorBefore(index, out int lineSepIndex);
+
+		return lineSepIndex + 1; // the amount of lines is the amount of line separators plus 1 ALWAYS
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetLine(int lineNumber, Span<char> destination, out int itemCount)
+	{
+		itemCount = 0;
+
+		if (IsEmpty || lineNumber < 0)
+			return false;
+
+		ComputeLineSeparators();
+
+		if (lineNumber >= lineSeparators.Count)
+			return false;
+
+		var spanEnd = lineSeparators[lineNumber];
+		var spanStartIndex = lineNumber == 0 ? 0 : (lineNumber - 1);
+
+		if (crFollowedByLf.Contains(lineSeparators[spanStartIndex]))
+			spanStartIndex++; // skip past the CR in the CRLF sequence
+
+		spanStartIndex++; // get the actual start of the next line instead of the line sep
+
+		var spanStart = lineSeparators[spanStartIndex];
+		var actualLineLength = spanEnd - spanStart + 1;
+		itemCount = Math.Min(actualLineLength, destination.Length);
+
+		data.AsSpan(spanStart, itemCount).CopyTo(destination);
+
+		return actualLineLength > destination.Length;
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetLineAt(int index, Span<char> line, out int itemCount)
+	{
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += data.Length;
+
+		if (IsOutOfBounds(index))
+			return false;
+
+		ComputeLineSeparators();
+
+		int spanStart = GetLineSeparatorBefore(index, out int lineSepBeforeIndex);
+
+		if (lineSepBeforeIndex != -1) // only skip necessary characters if the start of the span isn't 0
+		{
+			if (crFollowedByLf.Contains(spanStart))
+				spanStart++; // skip the LF in the CRLF sequence (if applicable)
+
+			if (index < data.Length - 1)
+				spanStart++; // skip to the actual start of the line (but don't error out doing so)
+		}
+
+		int spanEnd = GetLineSeparatorAfter(index, out _);
+
+		if (spanEnd > 0)
+			spanEnd--; // don't include the line separator
+
+		if (spanStart < spanEnd)
+			spanStart = spanEnd; // empty span
+
+		var actualLineLength = spanEnd - spanStart + 1;
+		itemCount = Math.Min(actualLineLength, line.Length);
+
+		data.AsSpan(spanStart, itemCount).CopyTo(line);
+
+		return actualLineLength <= line.Length;
+	}
+
+	/// <inheritdoc/>
+	public void Slice(SourceSpan sourceSpan, Span<char> slice)
+	{
+		if (slice.Length < sourceSpan.Length)
+			throw new ArgumentException("The slice's length is less than the span's length and therefore cannot contain the sliced region.", nameof(slice));
+
+		data.AsSpan(sourceSpan.Start.Index, sourceSpan.Length).CopyTo(slice);
+	}
+
+	public int GetLengthOfLine(int lineNumber)
+	{
+		// todo: this should return the minimum length of a line (#54)
+		throw new NotImplementedException();
+	}
+
+	public int GetLengthOfLineAt(int index)
+	{
+		// todo: this should return the minimum length of a line (#54)
+		throw new NotImplementedException();
+	}
+
+	/// <inheritdoc/>
+	public bool TryGetNextLineFrom(int index, Span<char> line, bool skipEmptyLines, out int itemCount)
+	{
+		// todo: this should return the next line (see TryGetNextLineFrom(int, Span<char>, int))
+		// but skip empty lines if skipEmptyLines = true
+		// see #52
+		throw new NotImplementedException();
+	}
+
+	/// <inheritdoc/>
+	public void BuildCache() => ComputeLineSeparators();
+
+	/// <inheritdoc/>
+	public void BuildCache(bool forceRebuild) => ComputeLineSeparators(forceRebuild);
 }

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -565,7 +565,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>,
 		if (spanEnd > 0)
 			spanEnd--; // don't include the line separator
 
-		if (spanStart < spanEnd)
+		if (spanStart > spanEnd)
 			spanStart = spanEnd; // empty span
 
 		int actualLineLength = spanEnd - spanStart + 1;

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 using OceanApocalypseStudios.RSML.Common;

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -249,9 +249,6 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (IsConventionallyOutOfRange(index))
 			throw new IndexOutOfRangeException("The index must be less than or equal to the buffer's length.");
 
-		if (index == Length)
-			return LineCount;
-
 		GetPreviousOrCurrentLineStartPosition(index, out int lineSepIndex);
 		return lineSepIndex;
 	}
@@ -342,10 +339,12 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 
 		ComputeLineStarts();
 		int spanStart = GetPreviousOrCurrentLineStartPosition(index, out _);
-		int spanEnd = GetNextLineStartPosition(index, out int nextLineStartIndex) - 1; // don't include the line separator
+		int spanEnd = GetNextLineStartPosition(index, out int nextLineStartIndex); // don't include the line separator
 
-		if (precededByCrLf.Contains(nextLineStartIndex))
+		if (precededByCrLf.Contains(spanEnd))
 			spanEnd--; // remove one extra line separator if it's CRLF
+
+		spanEnd--; // remove the line separator
 
 		int actualLineLength = spanEnd - spanStart;
 		itemCount = Math.Min(actualLineLength, line.Length);
@@ -616,6 +615,8 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			i = nextStart;
 		}
 
+		lineStarts.Add(Length); // add the EOF as the start of a line
+
 		CacheExists = true;
 	}
 
@@ -669,7 +670,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		if (nextIndex == lineStarts.Count)
 		{
 			// 2nd Case: the next line start is outside of the buffer (EOF convention)
-			lsListIndex = -1;
+			lsListIndex = nextIndex;
 			return Length;
 		}
 
@@ -681,6 +682,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	private int GetNextLineStartPosition(int index, out int lsListIndex) =>
 		// we use index + 1 to skip to the next line start if we're already standing on one :)
 		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index + 1), out lsListIndex);
+
 	private int GetNextOrCurrentLineStartPosition(int index, out int lsListIndex) =>
 		// we use the actual index because we might already be standing on the line start
 		GetNextLineStartFromInsertionPoint(lineStarts.BinarySearch(index), out lsListIndex);
@@ -709,7 +711,8 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			// 2nd Case: the next line start is outside of the buffer (EOF convention)
 			// however we're gonna decrement one because otherwise all indexes from the last line that are after
 			// start of said line suddenly become part of the EOF line
-			lsListIndex = previousIndex - 1;
+			// however this might also mean we're at last character
+			lsListIndex = previousIndex;
 			return Length;
 		}
 

--- a/src/RSML/Sources/IAsyncSource.cs
+++ b/src/RSML/Sources/IAsyncSource.cs
@@ -3,14 +3,11 @@
 using System;
 
 
-namespace OceanApocalypseStudios.RSML.Sources
-{
+namespace OceanApocalypseStudios.RSML.Sources;
 
-	/// <summary>
-	/// A data source that supports async mechanics for RSML's toolchain members.
-	/// </summary>
-	public interface IAsyncSource : IAsyncDisposable;
-
-}
+/// <summary>
+/// A data source that supports async mechanics for RSML's toolchain members.
+/// </summary>
+public interface IAsyncSource : IAsyncDisposable;
 
 #endif

--- a/src/RSML/Sources/ISource.cs
+++ b/src/RSML/Sources/ISource.cs
@@ -1,37 +1,32 @@
 ﻿using System;
 
 
-namespace OceanApocalypseStudios.RSML.Sources
+namespace OceanApocalypseStudios.RSML.Sources;
+
+/// <summary>
+/// A data source for RSML's toolchain members.
+/// </summary>
+public interface ISource : IDisposable
 {
+	/// <summary>
+	/// The length of the source.
+	/// </summary>
+	int Length { get; }
 
 	/// <summary>
-	/// A data source for RSML's toolchain members.
+	/// Whether the source is completely empty.
 	/// </summary>
-	public interface ISource : IDisposable
-	{
+	bool IsEmpty { get; }
 
-		/// <summary>
-		/// The length of the source.
-		/// </summary>
-		int Length { get; }
-
-		/// <summary>
-		/// Whether the source is completely empty.
-		/// </summary>
-		bool IsEmpty { get; }
-
-		/// <summary>
-		/// Converts an index into a location.
-		/// </summary>
-		/// <param name="index">The index.</param>
-		/// <param name="span">The output <see cref="SourceLocation"/>.</param>
-		/// <remarks>
-		/// In most implementations, this method is extremely expensive performance-wise as it requires
-		/// calculating all newlines up until <paramref name="index"/>.
-		/// </remarks>
-		/// <returns>True if the conversion was successful.</returns>
-		bool TryGetSourceLocation(int index, out SourceLocation span);
-
-	}
-
+	/// <summary>
+	/// Converts an index into a location.
+	/// </summary>
+	/// <param name="index">The index.</param>
+	/// <param name="span">The output <see cref="SourceLocation"/>.</param>
+	/// <remarks>
+	/// In most implementations, this method is extremely expensive performance-wise as it requires
+	/// calculating all newlines up until <paramref name="index"/>.
+	/// </remarks>
+	/// <returns>True if the conversion was successful.</returns>
+	bool TryGetSourceLocation(int index, out SourceLocation span);
 }

--- a/src/RSML/Sources/SourceLocation.cs
+++ b/src/RSML/Sources/SourceLocation.cs
@@ -2,139 +2,129 @@
 using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed out
 
 
-namespace OceanApocalypseStudios.RSML.Sources
+namespace OceanApocalypseStudios.RSML.Sources;
+
+
+/// <summary>
+/// Specifies the location of an item in a <see cref="ISource"/> (such as a <see cref="Buffers.IReadOnlyBuffer{TItem}"/>).
+/// </summary>
+/// <param name="index">The 0-based index.</param>
+/// <param name="line">The 0-based line number.</param>
+/// <param name="column">The 0-based column number (the index relative to the start of the line).</param>
+public readonly struct SourceLocation(int index, int line, int column) : IEquatable<SourceLocation>, IEquatable<int>, IComparable<SourceLocation>, IComparable<int>, IFormattable
 {
 
 	/// <summary>
-	/// Specifies the location of an item in a <see cref="ISource"/> (such as a <see cref="Buffers.IReadOnlyBuffer{TItem}"/>).
+	/// The 0-based line number, counting from the start of the source.
 	/// </summary>
-	/// <param name="index">The 0-based index.</param>
-	/// <param name="line">The 0-based line number.</param>
-	/// <param name="column">The 0-based column number (the index relative to the start of the line).</param>
-	public readonly struct SourceLocation(int index, int line, int column) : IEquatable<SourceLocation>, IEquatable<int>, IComparable<SourceLocation>, IComparable<int>, IFormattable
-	{
+	public int Line => line;
 
-		/// <summary>
-		/// The 0-based line number, counting from the start of the source.
-		/// </summary>
-		public int Line => line;
+	/// <summary>
+	/// The 0-based column number, which is the index of the item relative to the start of the line it is in.
+	/// </summary>
+	public int Column => column;
 
-		/// <summary>
-		/// The 0-based column number, which is the index of the item relative to the start of the line it is in.
-		/// </summary>
-		public int Column => column;
+	/// <summary>
+	/// The absolute 0-based index of the item in the source.
+	/// </summary>
+	public int Index => index;
 
-		/// <summary>
-		/// The absolute 0-based index of the item in the source.
-		/// </summary>
-		public int Index => index;
+	/// <summary>
+	/// Compares the index of the location to another index.
+	/// </summary>
+	/// <param name="other">The index to compare against.</param>
+	public int CompareTo(int other) => Index.CompareTo(other);
 
-		/// <summary>
-		/// Compares the index of the location to another index.
-		/// </summary>
-		/// <param name="other">The index to compare against.</param>
-		public int CompareTo(int other) => Index.CompareTo(other);
+	/// <inheritdoc/>
+	public int CompareTo(SourceLocation other) => throw new NotImplementedException();
 
-		/// <inheritdoc/>
-		public int CompareTo(SourceLocation other) => throw new NotImplementedException();
-
-		/// <inheritdoc/>
+	/// <inheritdoc/>
 #if NET10_0_OR_GREATER
-		public override bool Equals([NotNullWhen(true)] object? obj) =>
+	public override bool Equals([NotNullWhen(true)] object? obj) =>
 #elif NETSTANDARD2_0
-		public override bool Equals(object obj) =>
+	public override bool Equals(object obj) =>
 #endif
-			obj switch
-			{
-				SourceLocation location => Equals(location),
-				int index => Index == index,
-				_ => false
-			};
-
-		/// <summary>
-		/// Checks if two <see cref="SourceLocation"/>s are equal to each other.
-		/// </summary>
-		/// <param name="other">The other <see cref="SourceLocation"/>.</param>
-		/// <returns>True if equals.</returns>
-		public bool Equals(SourceLocation other) => Index == other.Index && Line == other.Line && Column == other.Column;
-
-		/// <summary>
-		/// Checks if two indexes are equal to each other.
-		/// </summary>
-		/// <param name="other">The other location's index.</param>
-		/// <returns>True if equals.</returns>
-		public bool Equals(int other) => Index.Equals(other);
-
-		/// <inheritdoc/>
-		public override int GetHashCode()
+		obj switch
 		{
-
-			unchecked
-			{
-
-				int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Index.GetHashCode();
-				hashCode = hashCode * InternalUtils.HashCodeMultiplier + Line.GetHashCode();
-				return hashCode * InternalUtils.HashCodeMultiplier + Column.GetHashCode();
-
-			}
-
-		}
-
-		/// <summary>
-		/// Returns a generic string representation of the current instance.
-		/// </summary>
-		/// <returns>The string representation.</returns>
-		public override string ToString() => $"SourceLocation(Index={Index}, Line={Line}, Column={Column})";
-
-		/// <summary>
-		/// Given a format, tries to return a string that uses said format as a basis for the representation.
-		/// If it fails, it defaults to <see cref="ToString()"/>.
-		/// </summary>
-		/// <param name="format">The format. Available formats are: CTOR (constructor-like string) and JSON (struct as JSON).</param>
-		/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
-		/// <returns>The string representation.</returns>
-		public string ToString(string? format, IFormatProvider? formatProvider) => format switch
-		{
-
-			"CTOR" or "I" or "INIT" or "NET" => $"new SourceLocation({Index}, {Line}, {Column})",
-			"JSON" => $$"""{ "index": {{Index}}, "line": {{Line}}, "column": {{Column}} }""",
-			_ => ToString()
-
+			SourceLocation location => Equals(location),
+			int index => Index == index,
+			_ => false
 		};
 
+	/// <summary>
+	/// Checks if two <see cref="SourceLocation"/>s are equal to each other.
+	/// </summary>
+	/// <param name="other">The other <see cref="SourceLocation"/>.</param>
+	/// <returns>True if equals.</returns>
+	public bool Equals(SourceLocation other) => Index == other.Index && Line == other.Line && Column == other.Column;
 
-		/// <summary>
-		/// Checks if two <see cref="SourceLocation"/>s are equal to each other.
-		/// </summary>
-		/// <returns>True if equals.</returns>
-		public static bool operator ==(SourceLocation left, SourceLocation right) => left.Equals(right);
+	/// <summary>
+	/// Checks if two indexes are equal to each other.
+	/// </summary>
+	/// <param name="other">The other location's index.</param>
+	/// <returns>True if equals.</returns>
+	public bool Equals(int other) => Index.Equals(other);
 
-		/// <summary>
-		/// Checks if two <see cref="SourceLocation"/>s are different from each other.
-		/// </summary>
-		/// <returns>True if different.</returns>
-		public static bool operator !=(SourceLocation left, SourceLocation right) => !left.Equals(right);
-
-		/// <summary>
-		/// Checks if <paramref name="left"/> is strictly less than <paramref name="right"/>.
-		/// </summary>
-		public static bool operator <(SourceLocation left, SourceLocation right) => left.Index < right.Index;
-
-		/// <summary>
-		/// Checks if <paramref name="left"/> is strictly greater than <paramref name="right"/>.
-		/// </summary>
-		public static bool operator >(SourceLocation left, SourceLocation right) => left.Index > right.Index;
-
-		/// <summary>
-		/// Checks if <paramref name="left"/> is greather than or equal to <paramref name="right"/>.
-		/// </summary>
-		public static bool operator >=(SourceLocation left, SourceLocation right) => left.Index >= right.Index;
-
-		/// <summary>
-		/// Checks if <paramref name="left"/> is less than or equal to <paramref name="right"/>.
-		/// </summary>
-		public static bool operator <=(SourceLocation left, SourceLocation right) => left.Index <= right.Index;
-
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Index.GetHashCode();
+			hashCode = hashCode * InternalUtils.HashCodeMultiplier + Line.GetHashCode();
+			return hashCode * InternalUtils.HashCodeMultiplier + Column.GetHashCode();
+		}
 	}
 
+	/// <summary>
+	/// Returns a generic string representation of the current instance.
+	/// </summary>
+	/// <returns>The string representation.</returns>
+	public override string ToString() => $"SourceLocation(Index={Index}, Line={Line}, Column={Column})";
+
+	/// <summary>
+	/// Given a format, tries to return a string that uses said format as a basis for the representation.
+	/// If it fails, it defaults to <see cref="ToString()"/>.
+	/// </summary>
+	/// <param name="format">The format. Available formats are: CTOR (constructor-like string) and JSON (struct as JSON).</param>
+	/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
+	/// <returns>The string representation.</returns>
+	public string ToString(string? format, IFormatProvider? formatProvider) => format switch
+	{
+		"CTOR" or "I" or "INIT" or "NET" => $"new SourceLocation({Index}, {Line}, {Column})",
+		"JSON" => $$"""{ "index": {{Index}}, "line": {{Line}}, "column": {{Column}} }""",
+		_ => ToString()
+	};
+
+	/// <summary>
+	/// Checks if two <see cref="SourceLocation"/>s are equal to each other.
+	/// </summary>
+	/// <returns>True if equals.</returns>
+	public static bool operator ==(SourceLocation left, SourceLocation right) => left.Equals(right);
+
+	/// <summary>
+	/// Checks if two <see cref="SourceLocation"/>s are different from each other.
+	/// </summary>
+	/// <returns>True if different.</returns>
+	public static bool operator !=(SourceLocation left, SourceLocation right) => !left.Equals(right);
+
+	/// <summary>
+	/// Checks if <paramref name="left"/> is strictly less than <paramref name="right"/>.
+	/// </summary>
+	public static bool operator <(SourceLocation left, SourceLocation right) => left.Index < right.Index;
+
+	/// <summary>
+	/// Checks if <paramref name="left"/> is strictly greater than <paramref name="right"/>.
+	/// </summary>
+	public static bool operator >(SourceLocation left, SourceLocation right) => left.Index > right.Index;
+
+	/// <summary>
+	/// Checks if <paramref name="left"/> is greather than or equal to <paramref name="right"/>.
+	/// </summary>
+	public static bool operator >=(SourceLocation left, SourceLocation right) => left.Index >= right.Index;
+
+	/// <summary>
+	/// Checks if <paramref name="left"/> is less than or equal to <paramref name="right"/>.
+	/// </summary>
+	public static bool operator <=(SourceLocation left, SourceLocation right) => left.Index <= right.Index;
 }

--- a/src/RSML/Sources/SourceLocation.cs
+++ b/src/RSML/Sources/SourceLocation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis; // needed for .NET 10 despite VS showing it grayed out
 
 
 namespace OceanApocalypseStudios.RSML.Sources;

--- a/src/RSML/Sources/SourceLocation.cs
+++ b/src/RSML/Sources/SourceLocation.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed out
+using System.Diagnostics.CodeAnalysis; // needed for .NET 10 despite VS showing it grayed out
 
 
 namespace OceanApocalypseStudios.RSML.Sources;

--- a/src/RSML/Sources/SourceLocation.cs
+++ b/src/RSML/Sources/SourceLocation.cs
@@ -4,16 +4,15 @@ using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed ou
 
 namespace OceanApocalypseStudios.RSML.Sources;
 
-
 /// <summary>
 /// Specifies the location of an item in a <see cref="ISource"/> (such as a <see cref="Buffers.IReadOnlyBuffer{TItem}"/>).
 /// </summary>
 /// <param name="index">The 0-based index.</param>
 /// <param name="line">The 0-based line number.</param>
 /// <param name="column">The 0-based column number (the index relative to the start of the line).</param>
-public readonly struct SourceLocation(int index, int line, int column) : IEquatable<SourceLocation>, IEquatable<int>, IComparable<SourceLocation>, IComparable<int>, IFormattable
+public readonly struct SourceLocation(int index, int line, int column) : IEquatable<SourceLocation>, IEquatable<int>, IFormattable,
+																		 IComparable<SourceLocation>, IComparable<int>
 {
-
 	/// <summary>
 	/// The 0-based line number, counting from the start of the source.
 	/// </summary>
@@ -47,8 +46,8 @@ public readonly struct SourceLocation(int index, int line, int column) : IEquata
 		obj switch
 		{
 			SourceLocation location => Equals(location),
-			int index => Index == index,
-			_ => false
+			int index               => Index == index,
+			_                       => false
 		};
 
 	/// <summary>
@@ -72,6 +71,7 @@ public readonly struct SourceLocation(int index, int line, int column) : IEquata
 		{
 			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Index.GetHashCode();
 			hashCode = hashCode * InternalUtils.HashCodeMultiplier + Line.GetHashCode();
+
 			return hashCode * InternalUtils.HashCodeMultiplier + Column.GetHashCode();
 		}
 	}
@@ -89,12 +89,13 @@ public readonly struct SourceLocation(int index, int line, int column) : IEquata
 	/// <param name="format">The format. Available formats are: CTOR (constructor-like string) and JSON (struct as JSON).</param>
 	/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
 	/// <returns>The string representation.</returns>
-	public string ToString(string? format, IFormatProvider? formatProvider) => format switch
-	{
-		"CTOR" or "I" or "INIT" or "NET" => $"new SourceLocation({Index}, {Line}, {Column})",
-		"JSON" => $$"""{ "index": {{Index}}, "line": {{Line}}, "column": {{Column}} }""",
-		_ => ToString()
-	};
+	public string ToString(string? format, IFormatProvider? formatProvider) =>
+		format switch
+		{
+			"CTOR" or "I" or "INIT" or "NET" => $"new SourceLocation({Index}, {Line}, {Column})",
+			"JSON"                           => $$"""{ "index": {{Index}}, "line": {{Line}}, "column": {{Column}} }""",
+			_                                => ToString()
+		};
 
 	/// <summary>
 	/// Checks if two <see cref="SourceLocation"/>s are equal to each other.

--- a/src/RSML/Sources/SourceSpan.cs
+++ b/src/RSML/Sources/SourceSpan.cs
@@ -5,123 +5,108 @@ using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed ou
 using OceanApocalypseStudios.RSML.Sources.Buffers;
 
 
-namespace OceanApocalypseStudios.RSML.Sources
+namespace OceanApocalypseStudios.RSML.Sources;
+
+/// <summary>
+/// Represents a span taken from a source.
+/// </summary>
+public readonly partial struct SourceSpan(SourceLocation start, SourceLocation end) : IFormattable
 {
+	/// <summary>
+	/// The start of the span.
+	/// </summary>
+	public readonly SourceLocation Start => start;
 
 	/// <summary>
-	/// Represents a span taken from a source.
+	/// The end of the span.
 	/// </summary>
-	public readonly partial struct SourceSpan(SourceLocation start, SourceLocation end) : IFormattable
-	{
+	public readonly SourceLocation End => end;
 
-		/// <summary>
-		/// The start of the span.
-		/// </summary>
-		public readonly SourceLocation Start => start;
+	/// <summary>
+	/// The length of the span.
+	/// </summary>
+	public readonly int Length => End.Index - Start.Index;
 
-		/// <summary>
-		/// The end of the span.
-		/// </summary>
-		public readonly SourceLocation End => end;
+	/// <summary>
+	/// The span is located in a single line.
+	/// </summary>
+	public bool IsSingleLine => Start.Line == End.Line;
 
-		/// <summary>
-		/// The length of the span.
-		/// </summary>
-		public readonly int Length => End.Index - Start.Index;
-
-		/// <summary>
-		/// The span is located in a single line.
-		/// </summary>
-		public bool IsSingleLine => Start.Line == End.Line;
-
-		/// <inheritdoc/>
+	/// <inheritdoc/>
 #if NET10_0_OR_GREATER
-		public override bool Equals([NotNullWhen(true)] object? obj) =>
+	public override bool Equals([NotNullWhen(true)] object? obj) =>
 #elif NETSTANDARD2_0
-		public override bool Equals(object obj) =>
+	public override bool Equals(object obj) =>
 #endif
-			obj is SourceSpan span && Equals(span);
+		obj is SourceSpan span && Equals(span);
 
-		/// <summary>
-		/// Checks whether two <see cref="SourceSpan"/>s are equals.
-		/// </summary>
-		/// <param name="other">The span to check against</param>
-		/// <returns>True if equals</returns>
-		public bool Equals(SourceSpan? other) => other is SourceSpan span && Start.Equals(span.Start) && End.Equals(span.End);
+	/// <summary>
+	/// Checks whether two <see cref="SourceSpan"/>s are equals.
+	/// </summary>
+	/// <param name="other">The span to check against</param>
+	/// <returns>True if equals</returns>
+	public bool Equals(SourceSpan? other) => other is SourceSpan span && Start.Equals(span.Start) && End.Equals(span.End);
 
-		/// <summary>
-		/// Checks whether two <see cref="SourceSpan"/>s are equals.
-		/// </summary>
-		/// <returns>True if equals</returns>
-		public static bool operator ==(SourceSpan left, SourceSpan right) => left.Equals(right);
+	/// <summary>
+	/// Checks whether two <see cref="SourceSpan"/>s are equals.
+	/// </summary>
+	/// <returns>True if equals</returns>
+	public static bool operator ==(SourceSpan left, SourceSpan right) => left.Equals(right);
 
-		/// <summary>
-		/// Checks whether two <see cref="SourceSpan"/>s are different from each other.
-		/// </summary>
-		/// <returns>True if different</returns>
-		public static bool operator !=(SourceSpan left, SourceSpan right) => left.Equals(right);
+	/// <summary>
+	/// Checks whether two <see cref="SourceSpan"/>s are different from each other.
+	/// </summary>
+	/// <returns>True if different</returns>
+	public static bool operator !=(SourceSpan left, SourceSpan right) => left.Equals(right);
 
-		/// <summary>
-		/// Returns a generic string representation of the current instance.
-		/// </summary>
-		/// <returns>The string representation.</returns>
-		public override string ToString() => $"SourceSpan(Start={Start}, End={End})";
+	/// <summary>
+	/// Returns a generic string representation of the current instance.
+	/// </summary>
+	/// <returns>The string representation.</returns>
+	public override string ToString() => $"SourceSpan(Start={Start}, End={End})";
 
-		/// <summary>
-		/// Given a source, tries to return a string that uses said source as a basis for the representation.
-		/// If it fails, it defaults to <see cref="ToString()"/>.
-		/// </summary>
-		/// <param name="source">The source.</param>
-		/// <returns>The string representation.</returns>
-		public string ToString(ISource source)
+	/// <summary>
+	/// Given a source, tries to return a string that uses said source as a basis for the representation.
+	/// If it fails, it defaults to <see cref="ToString()"/>.
+	/// </summary>
+	/// <param name="source">The source.</param>
+	/// <returns>The string representation.</returns>
+	public string ToString(ISource source)
+	{
+		switch (source)
 		{
+			case IReadOnlyBuffer<char> charBuffer:
+				Span<char> destination = stackalloc char[Length];
+				charBuffer.Slice(Start.Index, destination);
 
-			switch (source)
-			{
+				return destination.ToString();
 
-				case IReadOnlyBuffer<char> charBuffer:
-					Span<char> destination = stackalloc char[Length];
-					charBuffer.Slice(Start.Index, destination);
-
-					return destination.ToString();
-
-				default:
-					return ToString();
-
-			}
-
+			default:
+				return ToString();
 		}
-
-		/// <summary>
-		/// Given a format, tries to return a string that uses said format as a basis for the representation.
-		/// If it fails, it defaults to <see cref="ToString()"/>.
-		/// </summary>
-		/// <param name="format">The format. Available formats are: CTOR (constructor-like string) and JSON (struct as JSON).</param>
-		/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
-		/// <returns>The string representation.</returns>
-		public string ToString(string? format, IFormatProvider? formatProvider) => format switch
-		{
-
-			"CTOR" or "I" or "INIT" or "NET" => $"new SourceSpan({Start.ToString("ctor", null)}, {End.ToString("ctor", null)})",
-			"JSON" => $$"""{ "start": {{Start.ToString("JSON", null)}}, "end": {{End.ToString("JSON", null)}} }""",
-			_ => ToString()
-
-		};
-
-		/// <inheritdoc/>
-		public override int GetHashCode()
-		{
-
-			unchecked
-			{
-
-				int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Start.GetHashCode();
-				return hashCode * InternalUtils.HashCodeMultiplier + End.GetHashCode();
-
-			}
-
-		}
-
 	}
 
+	/// <summary>
+	/// Given a format, tries to return a string that uses said format as a basis for the representation.
+	/// If it fails, it defaults to <see cref="ToString()"/>.
+	/// </summary>
+	/// <param name="format">The format. Available formats are: CTOR (constructor-like string) and JSON (struct as JSON).</param>
+	/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
+	/// <returns>The string representation.</returns>
+	public string ToString(string? format, IFormatProvider? formatProvider) => format switch
+	{
+		"CTOR" or "I" or "INIT" or "NET" => $"new SourceSpan({Start.ToString("ctor", null)}, {End.ToString("ctor", null)})",
+		"JSON" => $$"""{ "start": {{Start.ToString("JSON", null)}}, "end": {{End.ToString("JSON", null)}} }""",
+		_ => ToString()
+	};
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Start.GetHashCode();
+			return hashCode * InternalUtils.HashCodeMultiplier + End.GetHashCode();
+		}
+	}
 }

--- a/src/RSML/Sources/SourceSpan.cs
+++ b/src/RSML/Sources/SourceSpan.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Data.Common;
 using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed out
+
 using OceanApocalypseStudios.RSML.Sources.Buffers;
 
 

--- a/src/RSML/Sources/SourceSpan.cs
+++ b/src/RSML/Sources/SourceSpan.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed out
-
 using OceanApocalypseStudios.RSML.Sources.Buffers;
 
 
@@ -33,11 +32,11 @@ public readonly partial struct SourceSpan(SourceLocation start, SourceLocation e
 	public bool IsSingleLine => Start.Line == End.Line;
 
 	/// <inheritdoc/>
-#if NET10_0_OR_GREATER
+	#if NET10_0_OR_GREATER
 	public override bool Equals([NotNullWhen(true)] object? obj) =>
-#elif NETSTANDARD2_0
+		#elif NETSTANDARD2_0
 	public override bool Equals(object obj) =>
-#endif
+		#endif
 		obj is SourceSpan span && Equals(span);
 
 	/// <summary>
@@ -93,12 +92,13 @@ public readonly partial struct SourceSpan(SourceLocation start, SourceLocation e
 	/// <param name="format">The format. Available formats are: CTOR (constructor-like string) and JSON (struct as JSON).</param>
 	/// <param name="formatProvider">Unused. Don't bother assigning it anything.</param>
 	/// <returns>The string representation.</returns>
-	public string ToString(string? format, IFormatProvider? formatProvider) => format switch
-	{
-		"CTOR" or "I" or "INIT" or "NET" => $"new SourceSpan({Start.ToString("ctor", null)}, {End.ToString("ctor", null)})",
-		"JSON" => $$"""{ "start": {{Start.ToString("JSON", null)}}, "end": {{End.ToString("JSON", null)}} }""",
-		_ => ToString()
-	};
+	public string ToString(string? format, IFormatProvider? formatProvider) =>
+		format switch
+		{
+			"CTOR" or "I" or "INIT" or "NET" => $"new SourceSpan({Start.ToString("ctor", null)}, {End.ToString("ctor", null)})",
+			"JSON"                           => $$"""{ "start": {{Start.ToString("JSON", null)}}, "end": {{End.ToString("JSON", null)}} }""",
+			_                                => ToString()
+		};
 
 	/// <inheritdoc/>
 	public override int GetHashCode()
@@ -106,6 +106,7 @@ public readonly partial struct SourceSpan(SourceLocation start, SourceLocation e
 		unchecked
 		{
 			int hashCode = InternalUtils.HashCodeSeed * InternalUtils.HashCodeMultiplier + Start.GetHashCode();
+
 			return hashCode * InternalUtils.HashCodeMultiplier + End.GetHashCode();
 		}
 	}

--- a/src/RSML/Sources/SourceSpan.cs
+++ b/src/RSML/Sources/SourceSpan.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis; // needed despite VS showing it grayed out
 
 using OceanApocalypseStudios.RSML.Sources.Buffers;
 

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -9,9 +9,8 @@ public class ReadOnlyStringBufferTests
 	private const string TestString01 = "Hey\r\nThis\rIs\u2029A Test \n Method\r\n\r\n.\u2028";
 
 	/*
-	 * todo: see why tests for TryGetLineAt are failing
-	 * todo: write more tests for GetLineNumberForIndex
 	 * todo: test all buffer methods (close open issues first)
+	 * todo: expand on these tested methods (test them further)
 	 */
 
 	[TestMethod]
@@ -45,11 +44,14 @@ public class ReadOnlyStringBufferTests
 	[DataRow(TestString01, 13, "A Test ")] // A in "A Test"
 	[DataRow(TestString01, 15, "A Test ")] // T in "Test"
 	[DataRow(TestString01, 22, " Method")] // M in "Method"
+	[DataRow(TestString01, 28, " Method")] // First CR in "\r\n\r\n."
 	[DataRow(TestString01, 29, " Method")] // First LF in "\r\n\r\n."
 	[DataRow(TestString01, 30, "")] // Second CR in "\r\n\r\n."
 	[DataRow(TestString01, 31, "")] // Second LF in "\r\n\r\n."
-	[DataRow(TestString01, 33, ".")] // End of file
-	public void TryGetLineAt(string data, int index, string expectedLine)
+	[DataRow(TestString01, 32, ".")] // Dot/point in Second LF in "\r\n\r\n."
+	[DataRow(TestString01, 33, ".")] // U2028 in ".\u2028"
+	[DataRow(TestString01, 34, "")] // End of file
+	public void TryGetLineFromIndex(string data, int index, string expectedLine)
 	{
 		var buffer = new ReadOnlyStringBuffer(data);
 		buffer.BuildCache();

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -9,10 +9,10 @@ public class ReadOnlyStringBufferTests
 	private const string TestString01 = "Hey\r\nThis\rIs\u2029A Test \n Method\r\n\r\n.\u2028";
 
 	[TestMethod]
-	[DataRow(TestString01, 0, 0)] // H in "Hey"
-	[DataRow(TestString01, 3, 1)] // CR in "Hey\r\n"
-	[DataRow(TestString01, 4, 1)] // LF in "Hey\r\n"
-	[DataRow(TestString01, 5, 1)] // T in "This"
+	[DataRow(TestString01, 0, 0)]  // H in "Hey"
+	[DataRow(TestString01, 3, 1)]  // CR in "Hey\r\n"
+	[DataRow(TestString01, 4, 1)]  // LF in "Hey\r\n"
+	[DataRow(TestString01, 5, 1)]  // T in "This"
 	[DataRow(TestString01, 13, 3)] // A in "A Test"
 	[DataRow(TestString01, 15, 3)] // T in "Test"
 	[DataRow(TestString01, 22, 4)] // M in "Method"
@@ -22,7 +22,7 @@ public class ReadOnlyStringBufferTests
 	[DataRow(TestString01, 33, 7)] // End of file
 	public void CountLinesBefore_CountsCorrectly(string data, int index, int expectedLineCount)
 	{
-		ReadOnlyStringBuffer buffer = new(data);
+		var buffer = new ReadOnlyStringBuffer(data);
 		buffer.BuildCache();
 		Assert.AreEqual(expectedLineCount, buffer.CountLinesBefore(index));
 	}

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -1,36 +1,29 @@
 ﻿using OceanApocalypseStudios.RSML.Sources.Buffers;
 
 
-namespace OceanApocalypseStudios.RSML.Tests.Sources
+namespace OceanApocalypseStudios.RSML.Tests.Sources;
+
+[TestClass]
+public class ReadOnlyStringBufferTests
 {
+	private const string TestString01 = "Hey\r\nThis\rIs\u2029A Test \n Method\r\n\r\n.\u2028";
 
-	[TestClass]
-	public class ReadOnlyStringBufferTests
+	[TestMethod]
+	[DataRow(TestString01, 0, 0)] // H in "Hey"
+	[DataRow(TestString01, 3, 1)] // CR in "Hey\r\n"
+	[DataRow(TestString01, 4, 1)] // LF in "Hey\r\n"
+	[DataRow(TestString01, 5, 1)] // T in "This"
+	[DataRow(TestString01, 13, 3)] // A in "A Test"
+	[DataRow(TestString01, 15, 3)] // T in "Test"
+	[DataRow(TestString01, 22, 4)] // M in "Method"
+	[DataRow(TestString01, 29, 5)] // First LF in "\r\n\r\n."
+	[DataRow(TestString01, 30, 6)] // Second CR in "\r\n\r\n."
+	[DataRow(TestString01, 31, 6)] // Second LF in "\r\n\r\n."
+	[DataRow(TestString01, 33, 7)] // End of file
+	public void CountLinesBefore_CountsCorrectly(string data, int index, int expectedLineCount)
 	{
-
-		private const string TestString01 = "Hey\r\nThis\rIs\u2029A Test \n Method\r\n\r\n.\u2028";
-
-		[TestMethod]
-		[DataRow(TestString01, 0, 0)] // H in "Hey"
-		[DataRow(TestString01, 3, 1)] // CR in "Hey\r\n"
-		[DataRow(TestString01, 4, 1)] // LF in "Hey\r\n"
-		[DataRow(TestString01, 5, 1)] // T in "This"
-		[DataRow(TestString01, 13, 3)] // A in "A Test"
-		[DataRow(TestString01, 15, 3)] // T in "Test"
-		[DataRow(TestString01, 22, 4)] // M in "Method"
-		[DataRow(TestString01, 29, 5)] // First LF in "\r\n\r\n."
-		[DataRow(TestString01, 30, 6)] // Second CR in "\r\n\r\n."
-		[DataRow(TestString01, 31, 6)] // Second LF in "\r\n\r\n."
-		[DataRow(TestString01, 33, 7)] // End of file
-		public void CountLinesBefore_CountsCorrectly(string data, int index, int expectedLineCount)
-		{
-
-			ReadOnlyStringBuffer buffer = new(data);
-			buffer.BuildCache();
-			Assert.AreEqual(expectedLineCount, buffer.CountLinesBefore(index));
-
-		}
-
+		ReadOnlyStringBuffer buffer = new(data);
+		buffer.BuildCache();
+		Assert.AreEqual(expectedLineCount, buffer.CountLinesBefore(index));
 	}
-
 }

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -55,7 +55,7 @@ public class ReadOnlyStringBufferTests
 		buffer.BuildCache();
 
 		Span<char> alloc = stackalloc char[expectedLine.Length];
-		Assert.IsTrue(buffer.TryGetLineAt(index, alloc, out int written));
+		Assert.IsTrue(buffer.TryGetLineFromIndex(index, alloc, out int written));
 
 		Assert.AreEqual(expectedLine, alloc.ToString());
 		Assert.AreEqual(expectedLine.Length, written);

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -20,10 +20,34 @@ public class ReadOnlyStringBufferTests
 	[DataRow(TestString01, 30, 6)] // Second CR in "\r\n\r\n."
 	[DataRow(TestString01, 31, 6)] // Second LF in "\r\n\r\n."
 	[DataRow(TestString01, 33, 7)] // End of file
-	public void CountLinesBefore_CountsCorrectly(string data, int index, int expectedLineCount)
+	public void CountLinesBefore(string data, int index, int expectedLineCount)
 	{
 		var buffer = new ReadOnlyStringBuffer(data);
 		buffer.BuildCache();
 		Assert.AreEqual(expectedLineCount, buffer.CountLinesBefore(index));
+	}
+
+	[TestMethod]
+	[DataRow(TestString01, 0, "Hey")]  // H in "Hey"
+	[DataRow(TestString01, 3, "Hey")]  // CR in "Hey\r\n"
+	[DataRow(TestString01, 4, "Hey")]  // LF in "Hey\r\n"
+	[DataRow(TestString01, 5, "This")]  // T in "This"
+	[DataRow(TestString01, 13, "A Test ")] // A in "A Test"
+	[DataRow(TestString01, 15, "A Test ")] // T in "Test"
+	[DataRow(TestString01, 22, " Method")] // M in "Method"
+	[DataRow(TestString01, 29, " Method")] // First LF in "\r\n\r\n."
+	[DataRow(TestString01, 30, "")] // Second CR in "\r\n\r\n."
+	[DataRow(TestString01, 31, "")] // Second LF in "\r\n\r\n."
+	[DataRow(TestString01, 33, ".")] // End of file
+	public void TryGetLineAt(string data, int index, string expectedLine)
+	{
+		var buffer = new ReadOnlyStringBuffer(data);
+		buffer.BuildCache();
+
+		Span<char> alloc = stackalloc char[expectedLine.Length];
+		Assert.IsTrue(buffer.TryGetLineAt(index, alloc, out int written));
+
+		Assert.AreEqual(expectedLine, alloc.ToString());
+		Assert.AreEqual(expectedLine.Length, written);
 	}
 }

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -10,21 +10,25 @@ public class ReadOnlyStringBufferTests
 
 	[TestMethod]
 	[DataRow(TestString01, 0, 0)]  // H in "Hey"
-	[DataRow(TestString01, 3, 1)]  // CR in "Hey\r\n"
-	[DataRow(TestString01, 4, 1)]  // LF in "Hey\r\n"
+	[DataRow(TestString01, 3, 0)]  // CR in "Hey\r\n"
+	[DataRow(TestString01, 4, 0)]  // LF in "Hey\r\n"
 	[DataRow(TestString01, 5, 1)]  // T in "This"
+	[DataRow(TestString01, 6, 1)]  // h in "This"
 	[DataRow(TestString01, 13, 3)] // A in "A Test"
 	[DataRow(TestString01, 15, 3)] // T in "Test"
 	[DataRow(TestString01, 22, 4)] // M in "Method"
-	[DataRow(TestString01, 29, 5)] // First LF in "\r\n\r\n."
-	[DataRow(TestString01, 30, 6)] // Second CR in "\r\n\r\n."
-	[DataRow(TestString01, 31, 6)] // Second LF in "\r\n\r\n."
-	[DataRow(TestString01, 33, 7)] // End of file
-	public void CountLinesBefore(string data, int index, int expectedLineCount)
+	[DataRow(TestString01, 28, 4)] // First CR in "\r\n\r\n."
+	[DataRow(TestString01, 29, 4)] // First LF in "\r\n\r\n."
+	[DataRow(TestString01, 30, 5)] // Second CR in "\r\n\r\n."
+	[DataRow(TestString01, 31, 5)] // Second LF in "\r\n\r\n."
+	[DataRow(TestString01, 32, 6)] // Dot/point in "\r\n\r\n."
+	[DataRow(TestString01, 33, 6)] // U2028 in ".\u2028"
+	[DataRow(TestString01, 34, 7)] // End of file
+	public void GetLineNumberAt(string data, int index, int expectedLineCount)
 	{
 		var buffer = new ReadOnlyStringBuffer(data);
 		buffer.BuildCache();
-		Assert.AreEqual(expectedLineCount, buffer.CountLinesBefore(index));
+		Assert.AreEqual(expectedLineCount, buffer.GetLineNumberAt(index));
 	}
 
 	[TestMethod]

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -24,11 +24,11 @@ public class ReadOnlyStringBufferTests
 	[DataRow(TestString01, 32, 6)] // Dot/point in "\r\n\r\n."
 	[DataRow(TestString01, 33, 6)] // U2028 in ".\u2028"
 	[DataRow(TestString01, 34, 7)] // End of file
-	public void GetLineNumberAt(string data, int index, int expectedLineCount)
+	public void GetLineNumberForIndex(string data, int index, int expectedLineCount)
 	{
 		var buffer = new ReadOnlyStringBuffer(data);
 		buffer.BuildCache();
-		Assert.AreEqual(expectedLineCount, buffer.GetLineNumberAt(index));
+		Assert.AreEqual(expectedLineCount, buffer.GetLineNumberForIndex(index));
 	}
 
 	[TestMethod]

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -8,6 +8,12 @@ public class ReadOnlyStringBufferTests
 {
 	private const string TestString01 = "Hey\r\nThis\rIs\u2029A Test \n Method\r\n\r\n.\u2028";
 
+	/*
+	 * todo: see why tests for TryGetLineAt are failing
+	 * todo: write more tests for GetLineNumberForIndex
+	 * todo: test all buffer methods (close open issues first)
+	 */
+
 	[TestMethod]
 	[DataRow(TestString01, 0, 0)]  // H in "Hey"
 	[DataRow(TestString01, 3, 0)]  // CR in "Hey\r\n"


### PR DESCRIPTION
This resolves #55 and tests both `TryGetLineFromIndex` (previously `TryGetLineAt`) and `GetLineNumberFromIndex` (previously `CountLinesBefore`).

To be squashed, in order to avoid git-cliff bugs.