### PR TITLE
Add methods for calculating the length of a line in the buffer

### DIFF
--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -75,6 +75,23 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	int CountWhile(Func<int, TItem, bool> predicate, int index);
 
 	/// <summary>
+	/// Returns the length of a line given its 0-based line number.
+	/// Line separators do not count towards the length.
+	/// </summary>
+	/// <param name="lineNumber">The 0-based line number.</param>
+	/// <returns>The length of the line.</returns>
+	int GetLengthOfLine(int lineNumber);
+
+	/// <summary>
+	/// Returns the length of a line given a 0-based index of one
+	/// of its items.
+	/// Line separators do not count towards the length.
+	/// </summary>
+	/// <param name="index">The 0-based index whose line is considered.</param>
+	/// <returns>The length of the line.</returns>
+	int GetLengthOfLineFromIndex(int index);
+
+	/// <summary>
 	/// Determines the 0-based line number of the line that contains the item located at <paramref name="index"/>.
 	/// </summary>
 	/// <param name="index">The index whose parent line's number is to be returned.</param>

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -30,6 +30,11 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	/// <inheritdoc/>
 	public int Length => data.Length;
 
+	/// <remarks>
+	/// <see cref="LineCount"/> automatically builds cache if
+	/// no cached data exists. No <see cref="BuildCache()"/> calls
+	/// are necessary.
+	/// </remarks>
 	/// <inheritdoc/>
 	public int LineCount
 	{
@@ -110,7 +115,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		isCrLf = false;
 
 		if (IsEmpty)
-			throw new BufferException("The buffer is empty.");
+			throw new BufferException("The buffer cannot be empty.");
 
 		if (index < 0)
 			index = Length + index; // -1 is (Length-1) etc
@@ -139,7 +144,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public int CountUntilNotWhitespace(int index)
 	{
 		if (IsEmpty)
-			throw new BufferException("The buffer is empty.");
+			throw new BufferException("The buffer cannot be empty.");
 
 		if (index < 0)
 			index = Length + index; // -1 is (Length-1) etc
@@ -169,7 +174,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public int CountUntilWhitespace(int index)
 	{
 		if (IsEmpty)
-			throw new BufferException("The buffer is empty.");
+			throw new BufferException("The buffer cannot be empty.");
 
 		if (index < 0)
 			index = Length + index; // -1 is (Length-1) etc
@@ -199,7 +204,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public int CountWhile(Func<int, char, bool> predicate, int index)
 	{
 		if (IsEmpty)
-			throw new BufferException("The buffer is empty.");
+			throw new BufferException("The buffer cannot be empty.");
 
 		if (index < 0)
 			index = Length + index; // -1 is (Length-1) etc
@@ -219,17 +224,38 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		return count;
 	}
 
+	/// <exception cref="BufferException">
+	/// The buffer is empty.
+	/// </exception>
+	/// <exception cref="ArgumentOutOfRangeException">
+	/// The given <paramref name="lineNumber"/> is negative or
+	/// is greater than the amount of lines (see <see cref="LineCount"/>).
+	/// </exception>
+	/// <inheritdoc/>
 	public int GetLengthOfLine(int lineNumber)
 	{
-		// todo: this should return the exact length of a line (#54)
-		throw new NotImplementedException();
+		if (IsEmpty)
+			throw new BufferException("The buffer cannot be empty.");
+
+		if (lineNumber < 0 || lineNumber >= LineCount) // LineCount already implicitly computes line starts so we don't need to manually compute them
+			throw new ArgumentOutOfRangeException(nameof(lineNumber), "The 0-based line number must be non-negative and less than the amount of lines in the buffer.");
+
+		if (lineNumber + 1 == LineCount)
+			return 0; // EOF means the line is empty
+
+		int start = lineStarts[lineNumber];
+		int end = lineStarts[lineNumber + 1];
+
+		if (precededByCrLf.Contains(end))
+			end--; // skip the extra line separator in the CRLF sequence
+
+		end--;
+
+		return end - start;
 	}
 
-	public int GetLengthOfLineAt(int index)
-	{
-		// todo: this should return the exact length of a line (#54)
-		throw new NotImplementedException();
-	}
+	/// <inheritdoc/>
+	public int GetLengthOfLineFromIndex(int index) => GetLengthOfLine(GetLineNumberForIndex(index));
 
 	/// <exception cref="BufferException">
 	/// The buffer is empty.
@@ -241,7 +267,7 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public int GetLineNumberForIndex(int index)
 	{
 		if (IsEmpty)
-			throw new BufferException("The buffer is empty.");
+			throw new BufferException("The buffer cannot be empty.");
 
 		if (index < 0)
 			index += Length;

--- a/tests/Sources/ReadOnlyStringBufferTests.cs
+++ b/tests/Sources/ReadOnlyStringBufferTests.cs
@@ -37,20 +37,36 @@ public class ReadOnlyStringBufferTests
 	}
 
 	[TestMethod]
-	[DataRow(TestString01, 0, "Hey")]  // H in "Hey"
-	[DataRow(TestString01, 3, "Hey")]  // CR in "Hey\r\n"
-	[DataRow(TestString01, 4, "Hey")]  // LF in "Hey\r\n"
-	[DataRow(TestString01, 5, "This")]  // T in "This"
+	[DataRow(TestString01, 0, 3)] // "Hey"
+	[DataRow(TestString01, 1, 4)] // "This"
+	[DataRow(TestString01, 2, 2)] // "Is"
+	[DataRow(TestString01, 3, 7)] // "A Test "
+	[DataRow(TestString01, 4, 7)] // " Method"
+	[DataRow(TestString01, 5, 0)] // ""
+	[DataRow(TestString01, 6, 1)] // "."
+	[DataRow(TestString01, 7, 0)] // EOF - empty by default
+	public void GetLengthOfLine(string data, int lineNumber, int expectedLength)
+	{
+		var buffer = new ReadOnlyStringBuffer(data);
+		buffer.BuildCache();
+		Assert.AreEqual(expectedLength, buffer.GetLengthOfLine(lineNumber));
+	}
+
+	[TestMethod]
+	[DataRow(TestString01, 0, "Hey")]      // H in "Hey"
+	[DataRow(TestString01, 3, "Hey")]      // CR in "Hey\r\n"
+	[DataRow(TestString01, 4, "Hey")]      // LF in "Hey\r\n"
+	[DataRow(TestString01, 5, "This")]     // T in "This"
 	[DataRow(TestString01, 13, "A Test ")] // A in "A Test"
 	[DataRow(TestString01, 15, "A Test ")] // T in "Test"
 	[DataRow(TestString01, 22, " Method")] // M in "Method"
 	[DataRow(TestString01, 28, " Method")] // First CR in "\r\n\r\n."
 	[DataRow(TestString01, 29, " Method")] // First LF in "\r\n\r\n."
-	[DataRow(TestString01, 30, "")] // Second CR in "\r\n\r\n."
-	[DataRow(TestString01, 31, "")] // Second LF in "\r\n\r\n."
-	[DataRow(TestString01, 32, ".")] // Dot/point in Second LF in "\r\n\r\n."
-	[DataRow(TestString01, 33, ".")] // U2028 in ".\u2028"
-	[DataRow(TestString01, 34, "")] // End of file
+	[DataRow(TestString01, 30, "")]        // Second CR in "\r\n\r\n."
+	[DataRow(TestString01, 31, "")]        // Second LF in "\r\n\r\n."
+	[DataRow(TestString01, 32, ".")]       // Dot/point in Second LF in "\r\n\r\n."
+	[DataRow(TestString01, 33, ".")]       // U2028 in ".\u2028"
+	[DataRow(TestString01, 34, "")]        // End of file
 	public void TryGetLineFromIndex(string data, int index, string expectedLine)
 	{
 		var buffer = new ReadOnlyStringBuffer(data);


### PR DESCRIPTION
This closes #54, by implementing methods `GetLengthOfLine` and `GetLengthOfLineFromIndex` (previously `GetLengthOfLineAt`).

To be squashed.