### PR TITLE
Add array-based methods to the read-only buffer interface and class, for convenience (#53)

### DIFF
--- a/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
+++ b/src/RSML/Sources/Buffers/IReadOnlyBuffer.cs
@@ -31,6 +31,20 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	TItem this[int index] { get; }
 
 	/// <summary>
+	/// Gets a single item out of the buffer.
+	/// </summary>
+	/// <param name="location">The location of the item to retrieve.</param>
+	/// <returns>The item.</returns>
+	TItem this[SourceLocation location] { get; }
+
+	/// <summary>
+	/// Gets a range of items out of the buffer.
+	/// </summary>
+	/// <param name="span">The span of items to get.</param>
+	/// <returns>The items.</returns>
+	TItem[] this[SourceSpan span] { get; }
+
+	/// <summary>
 	/// Counts the amount of items until the next line separator in the buffer, relative to a given <paramref name="index"/>.
 	/// Only line separators count - regular whitespace do not. CRLF counts as a single line separator, to avoid double counting.
 	/// </summary>
@@ -92,11 +106,75 @@ public interface IReadOnlyBuffer<TItem> : ISource, IEquatable<IReadOnlyBuffer<TI
 	int GetLengthOfLineFromIndex(int index);
 
 	/// <summary>
+	/// Given a 0-based line number, returns the matching line as an array of buffer items.
+	/// </summary>
+	/// <param name="lineNumber">The 0-based line number.</param>
+	/// <returns>The line as an array of items.</returns>
+	TItem[] GetLine(int lineNumber);
+
+	/// <summary>
+	/// Tries to read the line that contains the item at <paramref name="index"/>.
+	/// No end of line characters are added.
+	/// </summary>
+	/// <param name="index">The index at which to determine what the current line is.</param>
+	/// <returns>The line, as an array of items.</returns>
+	TItem[] GetLineFromIndex(int index);
+
+	/// <summary>
 	/// Determines the 0-based line number of the line that contains the item located at <paramref name="index"/>.
 	/// </summary>
 	/// <param name="index">The index whose parent line's number is to be returned.</param>
 	/// <returns>The 0-based number of the line that contains item located at <paramref name="index"/>.</returns>
 	int GetLineNumberFromIndex(int index);
+
+	/// <summary>
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of items verified by
+	/// <paramref name="itemKindPredicate"/> (if the starting index is verified by <paramref name="itemKindPredicate"/>)
+	/// or a span of content not verified by <paramref name="itemKindPredicate"/> (if
+	/// the starting index does not point to anything verified by <paramref name="itemKindPredicate"/>).
+	/// </summary>
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="itemKindPredicate">
+	/// A predicate that verifies if the first item in the selected range serves as the delimiter
+	/// (the predicate returns <c>true</c> if so). For example, if the predicate verifies <c>,</c>, then 
+	/// the current word if the buffer is <c>My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
+	/// is <c>My awesome buffer</c>. If the predicate verifies <c>;</c>, then the current word
+	/// if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
+	/// </param>
+	/// <param name="isItemKind">
+	/// True if the array is fully comprised of the item kind verified by <paramref name="itemKindPredicate"/>.
+	/// If False, no items verified by <paramref name="itemKindPredicate"/> is present.
+	/// </param>
+	/// <returns>The line, as an array of items.</returns>
+	TItem[] GetWord(int index, Func<int, TItem, bool> itemKindPredicate, out bool isItemKind);
+
+	/// <summary>
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of whitespace (if the starting index points to whitespace)
+	/// or a span of non-whitespace content (if the starting index does not point to whitespace).
+	/// </summary>
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="isWhitespace">True if the array is fully comprised of whitespace. If False, no whitespace is present.</param>
+	/// <returns>The line, as an array of items.</returns>
+	TItem[] GetWord(int index, out bool isWhitespace);
+
+	/// <summary>
+	/// Tries to read the word at index <paramref name="index"/>, which can be a span of <paramref name="itemKind"/> (if the starting index
+	/// points to <paramref name="itemKind"/>) or a span of non-<paramref name="itemKind"/> content (if
+	/// the starting index does not point to <paramref name="itemKind"/>).
+	/// </summary>
+	/// <param name="index">The index at which the word starts.</param>
+	/// <param name="itemKind">
+	/// The item that will serve as the delimiter. For example, if item kind is <c>,</c>, then 
+	/// the current word if the buffer is <c> My awesome buffer, isn't it cool?</c> starting from <paramref name="index"/>,
+	/// is <c> My awesome buffer</c>. If item kind is <c>;</c>, then 
+	/// the current word if the buffer is <c>;;so very awesome</c> starting from <paramref name="index"/>, is <c>;;</c>.
+	/// </param>
+	/// <param name="isItemKind">
+	/// True if the array is fully comprised of <paramref name="itemKind"/>.
+	/// If False, no <paramref name="itemKind"/> is present.
+	/// </param>
+	/// <returns>The line, as an array of items.</returns>
+	TItem[] GetWord(int index, TItem itemKind, out bool isItemKind);
 
 	/// <summary>
 	/// Slices a region of the buffer.

--- a/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
+++ b/src/RSML/Sources/Buffers/ReadOnlyStringBuffer.cs
@@ -51,6 +51,12 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	/// <inheritdoc/>
 	public char this[int index] => data[index];
 
+	/// <inheritdoc/>
+	public char this[SourceLocation location] => this[location.Index];
+
+	/// <inheritdoc/>
+	public char[] this[SourceSpan span] => Slice(span.Start.Index, span.Length);
+
 	/// <summary>
 	/// Initializes a new <see cref="ReadOnlyStringBuffer"/>
 	/// with a string.
@@ -284,6 +290,27 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 		return lineSepIndex;
 	}
 
+	/// <inheritdoc/>
+	public char[] GetLine(int lineNumber)
+	{
+		if (IsEmpty)
+			throw new BufferException("The buffer cannot be empty.");
+
+		if (lineNumber < 0 || lineNumber >= RawLineCount)
+			throw new ArgumentOutOfRangeException(nameof(lineNumber), "The 0-based line number must be non-negative and less than the amount of lines in the buffer.");
+
+		if (lineNumber + 1 == RawLineCount) // line count already implicitly builds cache
+			return []; // EOF means the line is empty
+
+		int start = lineStarts[lineNumber];
+		int length = GetLengthOfLine(lineNumber);
+
+		return data.AsSpan(start, length).ToArray();
+	}
+
+	/// <inheritdoc/>
+	public char[] GetLineFromIndex(int index) => GetLine(GetLineNumberFromIndex(index));
+
 	/// <remarks>
 	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
 	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
@@ -305,13 +332,103 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 			return new(0, 0, 0);
 
 		int lineNumber = GetLineNumberFromIndex(index);
-		
+
 		if (lineNumber >= lineStarts.Count)
 			throw new IndexOutOfRangeException("The index points to a line number that is out of range.");
 
 		ComputeLineStarts();
 
 		return new(index, lineNumber, index - lineStarts[lineNumber]);
+	}
+
+	/// <remarks>
+	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
+	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
+	/// considered part of any word.
+	/// </remarks>
+	/// <inheritdoc/>
+	public char[] GetWord(int index, out bool isWhitespace)
+	{
+		isWhitespace = false;
+
+		if (IsEmpty)
+			throw new BufferException("The buffer cannot be empty.");
+
+		if (index < 0)
+			index += Length;
+
+		if (IsOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than the buffer's length.");
+
+		isWhitespace = Char.IsWhiteSpace(data[index]);
+
+		// if first index is whitespace, the word is whitespace (ends when not whitespace/end of buffer)
+		// if first index not whitespace, the word is not whitespace (ends on whitespace/end of buffer)
+		int length = isWhitespace
+							? CountUntilNotWhitespace(index)
+							: CountUntilWhitespace(index);
+
+		return data.AsSpan(index, length).ToArray();
+	}
+
+	/// <remarks>
+	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
+	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
+	/// considered part of any word.
+	/// </remarks>
+	/// <inheritdoc/>
+	public char[] GetWord(int index, char itemKind, out bool isItemKind)
+	{
+		isItemKind = false;
+
+		if (IsEmpty)
+			throw new BufferException("The buffer cannot be empty.");
+
+		if (index < 0)
+			index += Length;
+
+		if (IsOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than the buffer's length.");
+
+		isItemKind = data[index] == itemKind;
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int length = isItemKind
+							? CountUntilNotMatch(index, itemKind)
+							: CountUntilMatch(index, itemKind);
+
+		return data.AsSpan(index, length).ToArray();
+	}
+
+	/// <remarks>
+	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
+	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
+	/// considered part of any word.
+	/// </remarks>
+	/// <inheritdoc/>
+	public char[] GetWord(int index, Func<int, char, bool> itemKindPredicate, out bool isItemKind)
+	{
+		isItemKind = false;
+
+		if (IsEmpty)
+			throw new BufferException("The buffer cannot be empty.");
+
+		if (index < 0)
+			index += Length;
+
+		if (IsOutOfRange(index))
+			throw new IndexOutOfRangeException("The index must be less than the buffer's length.");
+
+		isItemKind = itemKindPredicate(index, data[index]);
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int length = isItemKind
+							? CountWhile((i, c) => !itemKindPredicate(i, c), index)
+							: CountWhile(itemKindPredicate, index);
+
+		return data.AsSpan(index, length).ToArray();
 	}
 
 	/// <inheritdoc/>
@@ -372,37 +489,11 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 	public bool TryGetLineFromIndex(int index, Span<char> line, out int itemCount) =>
 		TryGetLine(GetLineNumberFromIndex(index), line, out itemCount);
 
-	/// <inheritdoc/>
-	public bool TryGetWord(int index, char itemKind, Span<char> destination, out bool isItemKind, out int itemCount)
-	{
-		isItemKind = false;
-		itemCount = 0;
-
-		if (IsEmpty)
-			return false;
-
-		if (index < 0)
-			index += Length;
-
-		if (IsOutOfRange(index))
-			return false;
-
-		isItemKind = data[index] == itemKind;
-
-		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
-		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
-		int actualLineLength = isItemKind
-								   ? CountUntilNotMatch(index, itemKind)
-								   : CountUntilMatch(index, itemKind);
-
-		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-		itemCount = charsToCopyAmount;
-
-		return destination.Length >= actualLineLength;
-	}
-
+	/// <remarks>
+	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
+	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
+	/// considered part of any word.
+	/// </remarks>
 	/// <inheritdoc/>
 	public bool TryGetWord(int index, Span<char> destination, out bool isWhitespace, out int itemCount)
 	{
@@ -426,14 +517,51 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 								   ? CountUntilNotWhitespace(index)
 								   : CountUntilWhitespace(index);
 
-		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-		itemCount = charsToCopyAmount;
+		itemCount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, itemCount).CopyTo(destination);;
 
 		return destination.Length >= actualLineLength;
 	}
 
+	/// <remarks>
+	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
+	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
+	/// considered part of any word.
+	/// </remarks>
+	/// <inheritdoc/>
+	public bool TryGetWord(int index, char itemKind, Span<char> destination, out bool isItemKind, out int itemCount)
+	{
+		isItemKind = false;
+		itemCount = 0;
+
+		if (IsEmpty)
+			return false;
+
+		if (index < 0)
+			index += Length;
+
+		if (IsOutOfRange(index))
+			return false;
+
+		isItemKind = data[index] == itemKind;
+
+		// if first index is KIND, the word is KIND (ends when not KIND/end of buffer)
+		// if first index not KIND, the word is not KIND (ends on KIND/end of buffer)
+		int actualLineLength = isItemKind
+								   ? CountUntilNotMatch(index, itemKind)
+								   : CountUntilMatch(index, itemKind);
+
+		itemCount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, itemCount).CopyTo(destination);
+
+		return destination.Length >= actualLineLength;
+	}
+
+	/// <remarks>
+	/// Unlike with other <see cref="ReadOnlyStringBuffer"/> methods, this one
+	/// does not accept the EOF index (index at <see cref="Length"/>), because it is not
+	/// considered part of any word.
+	/// </remarks>
 	/// <inheritdoc/>
 	public bool TryGetWord(int index, Func<int, char, bool> itemKindPredicate, Span<char> destination, out bool isItemKind, out int itemCount)
 	{
@@ -457,10 +585,8 @@ public class ReadOnlyStringBuffer : IReadOnlyBuffer<char>, ISupportsCache, IEqua
 								   ? CountWhile((i, c) => !itemKindPredicate(i, c), index)
 								   : CountWhile(itemKindPredicate, index);
 
-		int charsToCopyAmount = Math.Min(actualLineLength, destination.Length);
-		data.AsSpan(index, charsToCopyAmount).CopyTo(destination);
-
-		itemCount = charsToCopyAmount;
+		itemCount = Math.Min(actualLineLength, destination.Length);
+		data.AsSpan(index, itemCount).CopyTo(destination);
 
 		return destination.Length >= actualLineLength;
 	}


### PR DESCRIPTION
Added some array-based versions of existing methods to the read-only buffer interface and implemented them in the read-only string buffer. This version is important because some people might prefer the convenience of arrays, while others prefer the performance of spans.

**Closes:** #53
**Signed-off-by:** Matthew